### PR TITLE
fix: update DM MC02 clocks and status LED

### DIFF
--- a/boards/damiao/dm_mc02/dm_mc02.dts
+++ b/boards/damiao/dm_mc02/dm_mc02.dts
@@ -37,6 +37,21 @@
 
     aliases {
         sw0 = &user_button;
+        led-strip = &rgb_led;
+    };
+
+    power_en {
+        compatible = "gpio-leds";
+
+        power1: power1 {
+            label = "POWER_24V_1";
+            gpios = <&gpioc 14 GPIO_ACTIVE_HIGH>;
+        };
+
+        power2: power2 {
+            label = "POWER_24V_2";
+            gpios = <&gpioc 13 GPIO_ACTIVE_HIGH>;
+        };
     };
 };
 
@@ -54,34 +69,34 @@
 };
 
 &pll {
-    div-m = <12>;
-    mul-n = <275>;
-    div-p = <1>;    /* DIVP1: 550 MHz */
-    div-q = <2>;    /* DIVQ1: 275 MHz */
-    div-r = <2>;    /* DIVR1: 275 MHz */
+    div-m = <2>;
+    mul-n = <40>;
+    div-p = <1>;    /* DIVP1: 480 MHz */
+    div-q = <4>;    /* DIVQ1: 120 MHz */
+    div-r = <2>;    /* DIVR1: 240 MHz */
     clocks = <&clk_hse>;
     status = "okay";
 };
 
 &pll2 {
     div-m = <2>;
-    mul-n = <40>;
-    div-p = <4>;    /* DIVP2: 120 MHz */
-    div-q = <4>;    /* DIVQ2: 120 MHz */
-    div-r = <2>;    /* DIVR2: 240 MHz */
+    mul-n = <16>;
+    div-p = <2>;    /* DIVP2: 96 MHz */
+    div-q = <2>;    /* DIVQ2: 96 MHz */
+    div-r = <2>;    /* DIVR2: 96 MHz */
     clocks = <&clk_hse>;
     status = "okay";
 };
 
 &rcc {
     clocks = <&pll>;
-    clock-frequency = <DT_FREQ_M(550)>;
-    d1cpre = <1>;   /* CPU: 550   MHz */
-    hpre = <2>;     /* HCLK: 275   MHz */
-    d1ppre = <2>;   /* APB1: 137.5 MHz */
-    d2ppre1 = <2>;  /* APB2: 137.5 MHz */
-    d2ppre2 = <2>;  /* APB3: 137.5 MHz */
-    d3ppre = <2>;   /* APB4: 137.5 MHz */
+    clock-frequency = <DT_FREQ_M(480)>;
+    d1cpre = <1>;   /* CPU: 480 MHz */
+    hpre = <2>;     /* HCLK: 240 MHz */
+    d1ppre = <2>;   /* APB3: 120 MHz */
+    d2ppre1 = <2>;  /* APB1: 120 MHz */
+    d2ppre2 = <2>;  /* APB2: 120 MHz */
+    d3ppre = <2>;   /* APB4: 120 MHz */
 };
 
 &pwr {
@@ -111,7 +126,7 @@
 &spi2 {
     status = "okay";
     clocks = <&rcc STM32_CLOCK(APB1, 14U)>,
-             <&rcc STM32_SRC_PLL2_P SPI123_SEL(0)>;
+             <&rcc STM32_SRC_PLL1_Q SPI123_SEL(0)>;
     pinctrl-0 = <&spi2_sck_pb13 &spi2_miso_pc2_c &spi2_mosi_pc1>;
     pinctrl-names = "default";
     cs-gpios = <&gpioc 0 GPIO_ACTIVE_LOW>,
@@ -152,7 +167,7 @@
 &spi6 {
     status = "okay";
     clocks = <&rcc STM32_CLOCK(APB4, 5U)>,
-             <&rcc STM32_SRC_PLL2_Q SPI6_SEL(1)>;
+             <&rcc STM32_SRC_HSE SPI6_SEL(5)>;
     pinctrl-0 = <&spi6_sck_pa5 &spi6_mosi_pa7>;
     pinctrl-names = "default";
 
@@ -208,7 +223,7 @@
 can1: &fdcan1 {
     status = "okay";
     clocks = <&rcc STM32_CLOCK(APB1_2, 8U)>,
-             <&rcc STM32_SRC_PLL2_Q FDCAN_SEL(2)>;
+             <&rcc STM32_SRC_PLL1_Q FDCAN_SEL(1)>;
     pinctrl-0 = <&fdcan1_rx_pd0 &fdcan1_tx_pd1>;
     pinctrl-names = "default";
 };
@@ -216,7 +231,7 @@ can1: &fdcan1 {
 can2: &fdcan2 {
     status = "okay";
     clocks = <&rcc STM32_CLOCK(APB1_2, 8U)>,
-             <&rcc STM32_SRC_PLL2_Q FDCAN_SEL(2)>;
+             <&rcc STM32_SRC_PLL1_Q FDCAN_SEL(1)>;
     pinctrl-0 = <&fdcan2_rx_pb5 &fdcan2_tx_pb6>;
     pinctrl-names = "default";
 };
@@ -224,7 +239,7 @@ can2: &fdcan2 {
 can3: &fdcan3 {
     status = "okay";
     clocks = <&rcc STM32_CLOCK(APB1_2, 8U)>,
-             <&rcc STM32_SRC_PLL2_Q FDCAN_SEL(2)>;
+             <&rcc STM32_SRC_PLL1_Q FDCAN_SEL(1)>;
     pinctrl-0 = <&fdcan3_rx_pd12 &fdcan3_tx_pd13>;
     pinctrl-names = "default";
 };

--- a/boards/damiao/dm_mc02/dm_mc02_defconfig
+++ b/boards/damiao/dm_mc02/dm_mc02_defconfig
@@ -20,3 +20,7 @@ CONFIG_CAN=y
 CONFIG_LED_STRIP=y
 CONFIG_SENSOR=y
 CONFIG_BMI08X=y
+
+# Board status LED uses scheduler runtime stats to show CPU load.
+CONFIG_THREAD_RUNTIME_STATS=y
+CONFIG_SCHED_THREAD_USAGE_ALL=y

--- a/lib/ares/Kconfig
+++ b/lib/ares/Kconfig
@@ -32,6 +32,12 @@ config BOARD_LOG_LEVEL
 	help
 	  Set BOARD_LOG_LEVEL
 
+config ARES_BOARD_STATUS_LED
+	bool "ARES board status LED service"
+	default y
+	help
+	  Enable the board status LED service that maps CPU usage to LED color.
+
 config IMU_PWM_TEMP_CTRL
 	select PID
     bool "IMU_PWM_TEMP_CTRL"

--- a/lib/ares/board/init.c
+++ b/lib/ares/board/init.c
@@ -16,15 +16,22 @@
 
 LOG_MODULE_REGISTER(board_init, CONFIG_BOARD_LOG_LEVEL);
 
+#ifdef CONFIG_BOARD_DM_MC02
+#include <zephyr/drivers/led_strip.h>
+#else
 struct led_rgb {
 	uint8_t r;
 	uint8_t g;
 	uint8_t b;
 };
+#endif
 
 #ifdef CONFIG_BOARD_DM_MC02
 #define XT30_1_NODE DT_NODELABEL(power1)
 #define XT30_2_NODE DT_NODELABEL(power2)
+#define STRIP_NODE  DT_ALIAS(led_strip)
+
+const struct device *strip = DEVICE_DT_GET(STRIP_NODE);
 
 #if DT_NODE_EXISTS(XT30_1_NODE) && DT_NODE_HAS_PROP(XT30_1_NODE, gpios) &&                         \
 	DT_NODE_EXISTS(XT30_2_NODE) && DT_NODE_HAS_PROP(XT30_2_NODE, gpios)
@@ -37,14 +44,17 @@ void pwr_init(void)
 	gpio_pin_configure_dt(&pwr2, GPIO_OUTPUT_HIGH);
 }
 
+int set_rgb_led_brightness(struct led_rgb *color)
+{
+	return led_strip_update_rgb(strip, color, 1);
+}
+
 #define PWR_INIT pwr_init();
 #else
 #define PWR_INIT
 #endif
 
-#define LED_INIT
-
-#define set_rgb_led_brightness(color)
+#define LED_INIT led_init();
 
 #endif /* CONFIG_BOARD_DM_MC02 */
 
@@ -153,6 +163,12 @@ int set_rgb_led_brightness(struct led_rgb *color)
 
 #endif /* CONFIG_BOARD_ROBOMASTER_BOARD_C */
 
+#ifdef CONFIG_BOARD_DM_MC02
+#define STATUS_LED_MAX_CHANNEL 0x7e
+#else
+#define STATUS_LED_MAX_CHANNEL 0xff
+#endif
+
 #define RGB(_r, _g, _b) ((struct led_rgb){.r = (_r), .g = (_g), .b = (_b)})
 
 void led_serivce_func(void *p1, void *p2, void *p3)
@@ -188,8 +204,8 @@ void led_serivce_func(void *p1, void *p2, void *p3)
 #endif
 
 		// // 映射到RGB值 (红色表示高负载，绿色表示低负载)
-		uint8_t red = (uint8_t)((cpu_usage / 100.0f) * 0xff);
-		uint8_t green = (uint8_t)((1.0f - cpu_usage / 100.0f) * 0xff);
+		uint8_t red = (uint8_t)((cpu_usage / 100.0f) * STATUS_LED_MAX_CHANNEL);
+		uint8_t green = (uint8_t)((1.0f - cpu_usage / 100.0f) * STATUS_LED_MAX_CHANNEL);
 
 		// if (blue_decrease) {
 		// 	blue--;
@@ -218,6 +234,14 @@ static struct k_thread led_service_thread;
 void led_init(void)
 {
 	struct led_rgb color = RGB(0x4F, 0x4F, 0x4F);
+
+#ifdef CONFIG_BOARD_DM_MC02
+	if (!device_is_ready(strip)) {
+		LOG_ERR("WS2812 LED strip device is not ready");
+		return;
+	}
+#endif /* CONFIG_BOARD_DM_MC02 */
+
 	set_rgb_led_brightness(&color);
 	k_sleep(K_MSEC(300));
 
@@ -247,7 +271,9 @@ int board_init(void)
 {
 	k_sleep(K_MSEC(550));
 	PWR_INIT
+#if IS_ENABLED(CONFIG_ARES_BOARD_STATUS_LED)
 	LED_INIT
+#endif
 	LOG_INF("Board init done.");
 	return 0;
 }


### PR DESCRIPTION
## Summary
- update DM MC02 PLL/RCC and peripheral clock selections to the validated 480 MHz clock tree
- add LED strip alias and XT30 power-enable GPIO nodes
- enable thread runtime stats used by the status LED
- add a board status LED Kconfig switch and wire DM MC02 WS2812 status output with <50% channel cap

## Test
- `west build -p always -b dm_mc02 samples/motor/dm_demo -d /tmp/mambo-pr-dm-mc02-board-build -- -DZEPHYR_EXTRA_MODULES=/Users/ttwards/Documents/zephyr_ws/mambo-pr-dm-mc02-board -DBOARD_ROOT=/Users/ttwards/Documents/zephyr_ws/mambo-pr-dm-mc02-board -DDTS_ROOT=/Users/ttwards/Documents/zephyr_ws/mambo-pr-dm-mc02-board`