### PR TITLE
feat: add DM MC02 USB bulk sample config

### DIFF
--- a/samples/communication/ares_communication/boards/dm_mc02.conf
+++ b/samples/communication/ares_communication/boards/dm_mc02.conf
@@ -1,0 +1,10 @@
+# dm_mc02 uses USART10 as the debug console, so keep this sample focused on USB bulk.
+CONFIG_UART_INTERFACE=n
+
+CONFIG_LOG=y
+CONFIG_CONSOLE=y
+CONFIG_UART_CONSOLE=y
+CONFIG_LOG_BACKEND_UART=y
+
+CONFIG_SENSOR=n
+CONFIG_BMI08X=n

--- a/samples/communication/ares_communication/boards/dm_mc02.overlay
+++ b/samples/communication/ares_communication/boards/dm_mc02.overlay
@@ -1,0 +1,5 @@
+zephyr_udc0: &usbotg_hs {
+	pinctrl-0 = <&usb_otg_hs_dm_pa11 &usb_otg_hs_dp_pa12>;
+	pinctrl-names = "default";
+	status = "okay";
+};

--- a/samples/communication/ares_communication/src/main.c
+++ b/samples/communication/ares_communication/src/main.c
@@ -3,7 +3,9 @@
 #include <zephyr/logging/log.h>
 #include <zephyr/net_buf.h>
 #include <ares/interface/usb/usb_bulk.h>
+#if IS_ENABLED(CONFIG_UART_INTERFACE)
 #include <ares/interface/uart/uart.h>
+#endif
 #include <ares/protocol/dual/dual_protocol.h>
 #include <ares/ares_comm.h>
 
@@ -11,15 +13,21 @@
 
 LOG_MODULE_REGISTER(main_app, LOG_LEVEL_INF);
 
+#if IS_ENABLED(CONFIG_UART_INTERFACE)
 #define UART_DEV DT_NODELABEL(usart6)
 static const struct device *uart_dev = DEVICE_DT_GET(UART_DEV);
+#endif
 
 DUAL_PROPOSE_PROTOCOL_DEFINE(dual_protocol);
+#if IS_ENABLED(CONFIG_UART_INTERFACE)
 DUAL_PROPOSE_PROTOCOL_DEFINE(uart_protocol);
+#endif
 // 建议对UART使用CRC校验
 // DUAL_PROPOSE_PROTOCOL_DEFINE_CRC(uart_protocol);
 ARES_BULK_INTERFACE_DEFINE(usb_bulk_interface);
+#if IS_ENABLED(CONFIG_UART_INTERFACE)
 ARES_UART_INTERFACE_DEFINE(uart_interface);
+#endif
 
 int cnt = 0;
 int func_cb(uint32_t param1, uint32_t param2, uint32_t param3)
@@ -45,6 +53,7 @@ int main(void)
 {
 	LOG_INF("ARES USB Bulk & UART device is ready.");
 
+#if IS_ENABLED(CONFIG_UART_INTERFACE)
 	// Initialize UART interface
 	ares_uart_init_dev(&uart_interface, uart_dev);
 	int err_uart = ares_bind_interface(&uart_interface, &uart_protocol);
@@ -53,6 +62,7 @@ int main(void)
 	} else {
 		LOG_INF("ARES UART interface initialized successfully");
 	}
+#endif
 
 	// Initialize USB bulk interface
 	int err_usb = ares_bind_interface(&usb_bulk_interface, &dual_protocol);
@@ -68,10 +78,12 @@ int main(void)
 	sync_table_t *usb_pack =
 		dual_sync_add(&dual_protocol, 0x1, test, sizeof(test), (dual_trans_cb_t)sync_cb);
 
+#if IS_ENABLED(CONFIG_UART_INTERFACE)
 	dual_ret_cb_set(&uart_protocol, (dual_func_ret_cb_t)func_ret_cb);
 	dual_func_add(&uart_protocol, 0x1, (dual_trans_func_t)func_cb);
 	sync_table_t *uart_pack =
 		dual_sync_add(&uart_protocol, 0x1, test, sizeof(test), (dual_trans_cb_t)sync_cb);
+#endif
 
 	LOG_INF("ARES Dual Interface (USB Bulk + UART) device is ready.");
 
@@ -81,6 +93,7 @@ int main(void)
 	while (1) {
 		k_sleep(K_MSEC(1000));
 
+#if IS_ENABLED(CONFIG_UART_INTERFACE)
 		// Send data through both interfaces alternately
 		if (cnt % 2 == 0) {
 			// Send through USB
@@ -97,6 +110,13 @@ int main(void)
 				LOG_INF("Data sent via UART: %d", cnt);
 			}
 		}
+#else
+		if (err_usb == 0) {
+			dual_func_call(&dual_protocol, 0x1, 0x1, 0x2, cnt);
+			dual_sync_flush(&dual_protocol, usb_pack);
+			LOG_INF("Data sent via USB: %d", cnt);
+		}
+#endif
 		cnt++;
 	}
 


### PR DESCRIPTION
## Summary
- add dm_mc02 sample config and USB FS pin overlay for ares_communication
- allow the sample to build USB-only by guarding UART setup with CONFIG_UART_INTERFACE
- keep USART10 available for debug console logs on DM MC02

## Test
- `west build -p always -b dm_mc02 samples/communication/ares_communication -d /tmp/mambo-pr-ares-comm-dm-mc02-build -- -DZEPHYR_EXTRA_MODULES=/Users/ttwards/Documents/zephyr_ws/mambo-pr-ares-comm-dm-mc02 -DBOARD_ROOT=/Users/ttwards/Documents/zephyr_ws/mambo-pr-ares-comm-dm-mc02 -DDTS_ROOT=/Users/ttwards/Documents/zephyr_ws/mambo-pr-ares-comm-dm-mc02`

## Note
Runtime USB enumeration on MC02 also benefits from the USB lifecycle fix in #18.