### PR TITLE
fix(motor): require manual enable before bus traffic

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -7,7 +7,7 @@ on:
 
 permissions:
   contents: read
-  pull-requests: read
+  pull-requests: write
   issues: write
 
 jobs:

--- a/drivers/motor/common/common.c
+++ b/drivers/motor/common/common.c
@@ -68,10 +68,14 @@ int can_send_queued(const struct device *can_dev, struct can_frame *frame)
 		return -ENOSYS;
 	}
 
-	int err = k_sem_take(&tx_queue_sem[get_can_id(can_dev)], K_NO_WAIT);
+	int8_t can_id = get_can_id(can_dev);
+	if (can_id < 0) {
+		return -ENODEV;
+	}
+
+	int err = k_sem_take(&tx_queue_sem[can_id], K_NO_WAIT);
 	if (err == 0) {
-		err = can_send(can_dev, frame, K_NO_WAIT, can_tx_callback,
-			       &tx_queue_sem[get_can_id(can_dev)]);
+		err = can_send(can_dev, frame, K_NO_WAIT, can_tx_callback, &tx_queue_sem[can_id]);
 		// LOG_ERR("Send CAN frame: %d", err);
 		if (err) {
 			// LOG_ERR("TX queue full, will be put into msgq: %d", err);
@@ -80,7 +84,7 @@ int can_send_queued(const struct device *can_dev, struct can_frame *frame)
 		// LOG_ERR("CAN hardware TX queue is full. (err %d)", err);
 		struct tx_frame q_frame = {
 			.can_dev = can_dev,
-			.sem = &tx_queue_sem[get_can_id(can_dev)],
+			.sem = &tx_queue_sem[can_id],
 			.frame = *frame,
 		};
 		err = k_msgq_put(&can_tx_msgq, &q_frame, K_NO_WAIT);

--- a/drivers/motor/dji/dji_macros.h
+++ b/drivers/motor/dji/dji_macros.h
@@ -64,6 +64,7 @@
 		.canbus_id = 0,                                                                    \
 		.ctrl_struct = NULL,                                                               \
 		.online = false,                                                                   \
+		.enabled = false,                                                                  \
 		.convert_num = 0,                                                                  \
 		.current_mode_index = -1,                                                          \
 		.RAWangle = 0,                                                                     \

--- a/drivers/motor/dji/motor_dji.c
+++ b/drivers/motor/dji/motor_dji.c
@@ -201,13 +201,13 @@ int dji_set_mode(const struct device *dev, enum motor_mode mode)
 		return -ENOSYS;
 	}
 
-	data->current_mode_index = -1;
+	int8_t mode_index = -1;
 
 	for (int i = 0; i < SIZE_OF_ARRAY(cfg->common.pid_datas); i++) {
 		if ((cfg->common.pid_datas[i] == NULL ||
 		     cfg->common.pid_datas[i]->pid_dev == NULL) &&
 		    mode == ML_TORQUE) {
-			data->current_mode_index = i;
+			mode_index = i;
 			break;
 		}
 		if (cfg->common.pid_datas[i] == NULL) {
@@ -215,16 +215,17 @@ int dji_set_mode(const struct device *dev, enum motor_mode mode)
 		}
 		if (strcmp(cfg->common.capabilities[i], mode_str) == 0) {
 			pid_calc(cfg->common.pid_datas[i]);
-			data->current_mode_index = i;
+			mode_index = i;
 			break;
 		}
 	}
 
-	if (data->current_mode_index == -1) {
+	if (mode_index == -1) {
 		LOG_ERR("No motor mode found for %s", mode_str);
 		return -ENOSYS;
 	}
 
+	data->current_mode_index = mode_index;
 	data->common.mode = mode;
 
 	return 0;
@@ -272,10 +273,10 @@ void dji_control(const struct device *dev, enum motor_cmd cmd)
 
 	switch (cmd) {
 	case ENABLE_MOTOR:
-		data->online = true;
+		data->enabled = true;
 		break;
 	case DISABLE_MOTOR:
-		data->online = false;
+		data->enabled = false;
 		break;
 	case SET_ZERO:
 		data->angle_add = 0;
@@ -295,7 +296,6 @@ void dji_control(const struct device *dev, enum motor_cmd cmd)
 		break;
 	case CLEAR_ERROR:
 		data->missed_times = 0;
-		data->online = true;
 		if (cfg->is_dm_motor) {
 			frame.id = 0x7FF;
 			frame.flags = 0;
@@ -314,18 +314,20 @@ int dji_get(const struct device *dev, motor_status_t *status)
 {
 	struct dji_motor_data *data = dev->data;
 	const struct dji_motor_config *cfg = dev->config;
-
-	if (strcmp(cfg->common.capabilities[data->current_mode_index], "torque") == 0) {
-		status->mode = ML_TORQUE;
-	} else if (strcmp(cfg->common.capabilities[data->current_mode_index], "angle") == 0) {
-		status->mode = ML_ANGLE;
-	} else if (strcmp(cfg->common.capabilities[data->current_mode_index], "speed") == 0) {
-		status->mode = ML_SPEED;
-	} else if (strcmp(cfg->common.capabilities[data->current_mode_index], "mit") == 0) {
-		status->mode = MIT;
-	}
+	int8_t mode_index = data->current_mode_index;
 
 	memcpy(status, &data->common, sizeof(motor_status_t));
+	if (mode_index >= 0 && mode_index < SIZE_OF_ARRAY(cfg->common.capabilities)) {
+		if (strcmp(cfg->common.capabilities[mode_index], "torque") == 0) {
+			status->mode = ML_TORQUE;
+		} else if (strcmp(cfg->common.capabilities[mode_index], "angle") == 0) {
+			status->mode = ML_ANGLE;
+		} else if (strcmp(cfg->common.capabilities[mode_index], "speed") == 0) {
+			status->mode = ML_SPEED;
+		} else if (strcmp(cfg->common.capabilities[mode_index], "mit") == 0) {
+			status->mode = MIT;
+		}
+	}
 
 	return 0;
 }
@@ -360,7 +362,6 @@ int dji_init(const struct device *dev)
 
 		data->ctrl_struct->full_handle.handler = dji_tx_handler;
 
-		data->online = true;
 		data->pid_count = SIZE_OF_ARRAY(cfg->common.pid_datas);
 		data->current_mode_index = data->pid_count;
 		for (int i = 0;
@@ -486,6 +487,7 @@ void can_rx_callback(const struct device *can_dev, struct can_frame *frame, void
 	data->RAWrpm = COMBINE_HL8(rx_frame.data[2], rx_frame.data[3]);
 	data->RAWcurrent = COMBINE_HL8(rx_frame.data[4], rx_frame.data[5]);
 	data->RAWtemp = rx_frame.data[6];
+	data->online = true;
 	data->ctrl_struct->flags |= 1 << id;
 	data->prev_time = (data->curr_time == 0) ? (curr_time - 1) : data->curr_time;
 	data->curr_time = curr_time;
@@ -749,7 +751,13 @@ void dji_tx_handler(struct k_work *work)
 				}
 				const struct device *dev = ctrl_struct->motor_devs[id_temp];
 				struct dji_motor_data *data = dev->data;
-				if (id_temp < 8 && data->online) {
+				if (id_temp < 8) {
+					if (!data->enabled || !data->online) {
+						txframe.data[j * 2] = 0;
+						txframe.data[j * 2 + 1] = 0;
+						packed = true;
+						continue;
+					}
 					if (!data->calculated) {
 						motor_calc(ctrl_struct->motor_devs[id_temp]);
 						data->calculated = true;

--- a/drivers/motor/dji/motor_dji.h
+++ b/drivers/motor/dji/motor_dji.h
@@ -61,6 +61,7 @@ struct dji_motor_data {
 
 	// Control status
 	bool online;
+	bool enabled;
 	uint8_t convert_num;
 	int8_t current_mode_index;
 

--- a/drivers/motor/dm/motor_dm.c
+++ b/drivers/motor/dm/motor_dm.c
@@ -95,23 +95,30 @@ void dm_control(const struct device *dev, enum motor_cmd cmd)
 
 	switch (cmd) {
 	case ENABLE_MOTOR:
-		memcpy(frame.data, enable_frame, 8);
-		can_send_queued(cfg->common.phy, &frame);
 		data->enable = true;
+		dm_motor_set_mode(dev, data->common.mode);
+		if (!data->enable) {
+			return;
+		}
+		frame.id = cfg->common.tx_id + data->tx_offset;
+		memcpy(frame.data, enable_frame, 8);
+		err = can_send_queued(cfg->common.phy, &frame);
 		break;
 	case DISABLE_MOTOR:
 		memcpy(frame.data, disable_frame, 8);
-		can_send_queued(cfg->common.phy, &frame);
+		err = can_send_queued(cfg->common.phy, &frame);
 		data->enable = false;
 		break;
 	case SET_ZERO:
 		memcpy(frame.data, set_zero_frame, 8);
+		err = can_send_queued(cfg->common.phy, &frame);
 		break;
 	case CLEAR_PID:
 		memset(&data->params, 0, sizeof(data->params));
 		break;
 	case CLEAR_ERROR:
 		memcpy(frame.data, clear_error_frame, 8);
+		err = can_send_queued(cfg->common.phy, &frame);
 		break;
 	}
 	if (err != 0) {
@@ -241,22 +248,30 @@ void dm_motor_set_mode(const struct device *dev, enum motor_mode mode)
 	case MIT:
 		snprintf(mode_str, sizeof(mode_str), "mit");
 		data->tx_offset = 0x0;
-		dm_edit_reg_value(cfg->common.phy, cfg->common.tx_id, 0x0A, 0x01);
+		if (data->enable) {
+			dm_edit_reg_value(cfg->common.phy, cfg->common.tx_id, 0x0A, 0x01);
+		}
 		break;
 	case PV:
 		snprintf(mode_str, sizeof(mode_str), "pv");
 		data->tx_offset = 0x100;
-		dm_edit_reg_value(cfg->common.phy, cfg->common.tx_id, 0x0A, 0x02);
+		if (data->enable) {
+			dm_edit_reg_value(cfg->common.phy, cfg->common.tx_id, 0x0A, 0x02);
+		}
 		break;
 	case VO:
 		snprintf(mode_str, sizeof(mode_str), "vo");
 		data->tx_offset = 0x200;
-		dm_edit_reg_value(cfg->common.phy, cfg->common.tx_id, 0x0A, 0x03);
+		if (data->enable) {
+			dm_edit_reg_value(cfg->common.phy, cfg->common.tx_id, 0x0A, 0x03);
+		}
 		break;
 	case HYBRID:
 		snprintf(mode_str, sizeof(mode_str), "hybrid");
 		data->tx_offset = 0x300;
-		dm_edit_reg_value(cfg->common.phy, cfg->common.tx_id, 0x0A, 0x04);
+		if (data->enable) {
+			dm_edit_reg_value(cfg->common.phy, cfg->common.tx_id, 0x0A, 0x04);
+		}
 		break;
 	default:
 		data->online = false;
@@ -290,10 +305,12 @@ void dm_motor_set_mode(const struct device *dev, enum motor_mode mode)
 			float f;
 			uint32_t u;
 		} conv;
-		conv.f = data->params.k_p;
-		dm_edit_reg_value(cfg->common.phy, cfg->common.tx_id, 0x19, conv.u);
-		conv.f = data->params.k_i;
-		dm_edit_reg_value(cfg->common.phy, cfg->common.tx_id, 0x1A, conv.u);
+		if (data->enable) {
+			conv.f = data->params.k_p;
+			dm_edit_reg_value(cfg->common.phy, cfg->common.tx_id, 0x19, conv.u);
+			conv.f = data->params.k_i;
+			dm_edit_reg_value(cfg->common.phy, cfg->common.tx_id, 0x1A, conv.u);
+		}
 	} else if (mode == PV) {
 		LOG_ERR("PV mode params setting not supported");
 	}
@@ -324,6 +341,9 @@ int dm_set(const struct device *dev, motor_status_t *status)
 	}
 
 	struct can_frame tx_frame;
+	if (!data->enable || !data->enabled) {
+		return 0;
+	}
 	dm_motor_pack(dev, &tx_frame);
 	can_send_queued(cfg->common.phy, &tx_frame);
 	data->last_tx_time = k_uptime_get();
@@ -377,6 +397,9 @@ void dm_tx_data_handler(struct k_work *work)
 		struct dm_motor_data *data = motor_devices[i]->data;
 		const struct dm_motor_config *cfg = motor_devices[i]->config;
 
+		if (!data->enable) {
+			continue;
+		}
 		if ((data->online && data->enable) && data->tx_cnt >= 3) {
 			if (!data->enabled) {
 				dm_control(motor_devices[i], ENABLE_MOTOR);
@@ -386,7 +409,7 @@ void dm_tx_data_handler(struct k_work *work)
 				dm_control(motor_devices[i], CLEAR_ERROR);
 			}
 		}
-		if (now - data->last_tx_time >= 1000 / cfg->freq) {
+		if (data->enabled && now - data->last_tx_time >= 1000 / cfg->freq) {
 			dm_motor_pack(motor_devices[i], &tx_frame);
 			can_send_queued(cfg->common.phy, &tx_frame);
 			data->last_tx_time = now;
@@ -426,12 +449,6 @@ void dm_init_handler(struct k_work *work)
 	}
 
 	k_sleep(K_MSEC(500));
-
-	for (int i = 0; i < MOTOR_COUNT; i++) {
-		dm_control(motor_devices[i], ENABLE_MOTOR);
-		struct dm_motor_data *data = motor_devices[i]->data;
-		data->prev_recv_time = k_uptime_get();
-	}
 
 	k_timer_start(&dm_tx_timer, K_NO_WAIT, K_MSEC(9));
 	k_timer_user_data_set(&dm_tx_timer, &dm_tx_data_handle);

--- a/drivers/motor/dm/motor_dm.h
+++ b/drivers/motor/dm/motor_dm.h
@@ -129,9 +129,9 @@ K_TIMER_DEFINE(dm_tx_timer, dm_tx_isr_handler, NULL);
 	static struct dm_motor_data dm_motor_data_##inst = {                                       \
 		.common = MOTOR_DT_DRIVER_DATA_INST_GET(inst),                                     \
 		.tx_offset = 0,                                                                    \
-		.online = true,                                                                    \
-		.enable = true,                                                                    \
-		.enabled = true,                                                                   \
+		.online = false,                                                                   \
+		.enable = false,                                                                   \
+		.enabled = false,                                                                  \
 		.prev_recv_time = 0,                                                               \
 		.err = 0,                                                                          \
 		.delta_deg_sum = 0,                                                                \

--- a/drivers/motor/lk/motor_lk.c
+++ b/drivers/motor/lk/motor_lk.c
@@ -76,6 +76,7 @@ void lk_motor_control(const struct device *dev, enum motor_cmd cmd)
 		k_msleep(10);
 		data->online = true;
 		data->enabled = true;
+		k_work_submit_to_queue(&lk_work_queue, &lk_txpid_data_handle);
 		break;
 	case DISABLE_MOTOR:
 		frame.data[0] = LK_CMD_MOTOR_OFF; // 0x80
@@ -280,7 +281,9 @@ static void lk_can_rx_handler(const struct device *can_dev, struct can_frame *fr
 
 	struct lk_motor_data *data = (struct lk_motor_data *)(motor_devices[idx]->data);
 	const struct lk_motor_cfg *cfg = (const struct lk_motor_cfg *)(motor_devices[idx]->config);
-	data->missed_times--;
+	if (data->missed_times > 0) {
+		data->missed_times--;
+	}
 	if (!data->online) {
 		data->missed_times = 0;
 		data->online = true;
@@ -367,6 +370,9 @@ void lk_txpid_data_handler(struct k_work *work)
 	for (int i = 0; i < MOTOR_COUNT; i++) {
 		struct lk_motor_data *data = motor_devices[i]->data;
 		const struct lk_motor_cfg *cfg = motor_devices[i]->config;
+		if (!data->enabled) {
+			continue;
+		}
 		if (data->pidupdate[0] || data->pidupdate[1] || data->pidupdate[2]) {
 			tx_frame.id = LK_CMD_ID_BASE + cfg->id; // 0x160 + ID
 			tx_frame.dlc = 8;
@@ -396,7 +402,7 @@ void lk_txpid_data_handler(struct k_work *work)
 			if (data->pidupdate[1]) {
 				tx_frame.data[0] = LK_SET_PARAM;
 				tx_frame.data[1] = LK_PID_SPEED_UPDATE;
-				data->pidupdate[0] = false;
+				data->pidupdate[1] = false;
 
 				// Kp
 				int16_t kp_val = (int16_t)(data->params[1].k_p);
@@ -416,7 +422,7 @@ void lk_txpid_data_handler(struct k_work *work)
 			if (data->pidupdate[2]) {
 				tx_frame.data[0] = LK_SET_PARAM;
 				tx_frame.data[1] = LK_PID_TORQUE_UPDATE;
-				data->pidupdate[0] = false;
+				data->pidupdate[2] = false;
 
 				// Kp
 				int16_t kp_val = (int16_t)(data->params[2].k_p);
@@ -441,14 +447,15 @@ void lk_init_handler(struct k_work *work)
 	// LOG_DBG("lk_init_handler");
 
 	for (int i = 0; i < MOTOR_COUNT; i++) {
-
 		const struct lk_motor_cfg *cfg =
 			(const struct lk_motor_cfg *)(motor_devices[i]->config);
 		struct lk_motor_data *data = motor_devices[i]->data;
+
 		reg_can_dev(cfg->common.phy);
 		data->pidupdate[0] = true;
 		data->pidupdate[1] = true;
 		data->pidupdate[2] = true;
+
 		// 注册 CAN 滤波器
 		// 接收 ID = 0x180 + ID
 		filters[i].flags = 0; // 标准帧
@@ -461,13 +468,13 @@ void lk_init_handler(struct k_work *work)
 		if (err < 0) {
 			LOG_ERR("Error adding CAN filter (err %d)", err);
 		}
-		for (int i = 0; i < SIZE_OF_ARRAY(cfg->common.capabilities); i++) {
 
-			if (cfg->common.pid_datas[i]->pid_dev == NULL) {
+		for (int j = 0; j < SIZE_OF_ARRAY(cfg->common.capabilities); j++) {
+			if (cfg->common.pid_datas[j]->pid_dev == NULL) {
 				break;
 			}
 
-			const char *cap_name = cfg->common.capabilities[i];
+			const char *cap_name = cfg->common.capabilities[j];
 			int pid_idx = -1;
 
 			// 0->Angle, 1->Speed, 2->Torque
@@ -483,7 +490,7 @@ void lk_init_handler(struct k_work *work)
 
 			if (pid_idx != -1) {
 				struct pid_config params;
-				pid_get_params(cfg->common.pid_datas[i], &params);
+				pid_get_params(cfg->common.pid_datas[j], &params);
 
 				if (data->params[pid_idx].k_p != params.k_p ||
 				    data->params[pid_idx].k_d != params.k_d) {
@@ -495,11 +502,10 @@ void lk_init_handler(struct k_work *work)
 				}
 			}
 		}
-		lk_motor_control(motor_devices[i], ENABLE_MOTOR);
-		k_sleep(K_USEC(120));
+
 		// lk_motor_control(motor_devices[i], SET_ZERO);
 	}
-	k_work_submit_to_queue(&lk_work_queue, &lk_txpid_data_handle);
+
 	lk_tx_timer.expiry_fn = lk_tx_isr_handler;
 	k_timer_start(&lk_tx_timer, K_MSEC(600), K_MSEC(4));
 	k_timer_user_data_set(&lk_tx_timer, &lk_tx_data_handle);

--- a/drivers/motor/mi/motor_mi.c
+++ b/drivers/motor/mi/motor_mi.c
@@ -18,6 +18,8 @@ LOG_MODULE_REGISTER(motor_mi, CONFIG_MOTOR_LOG_LEVEL);
 
 struct k_sem tx_frame_sem;
 
+static int mi_motor_apply_mode(const struct device *dev, enum motor_mode mode, bool send);
+
 static float uint16_to_float(uint16_t x, float x_min, float x_max, int bits)
 {
 	uint32_t span = (1 << bits) - 1;
@@ -72,9 +74,12 @@ void mi_motor_control(const struct device *dev, enum motor_cmd cmd)
 	switch (cmd) {
 	case ENABLE_MOTOR:
 
+		if (mi_motor_apply_mode(dev, data->common.mode, true) < 0) {
+			LOG_ERR("Failed to set motor mode before enabling");
+			return;
+		}
 		mi_can_id->mi_msg_mode = Communication_Type_MotorEnable;
 		can_send_queued(cfg->common.phy, &frame);
-		data->online = true;
 		data->enabled = true;
 		break;
 	case DISABLE_MOTOR:
@@ -98,6 +103,7 @@ void mi_motor_control(const struct device *dev, enum motor_cmd cmd)
 	case CLEAR_ERROR:
 
 		break;
+	default:
 		LOG_ERR("Unsupport motor command: %d", cmd);
 		return;
 	}
@@ -188,14 +194,12 @@ static void mi_motor_pack(const struct device *dev, struct can_frame *frame)
 	}
 }
 
-int mi_motor_set_mode(const struct device *dev, enum motor_mode mode)
+static int mi_motor_apply_mode(const struct device *dev, enum motor_mode mode, bool send)
 {
 
 	struct mi_motor_data *data = dev->data;
 	const struct mi_motor_cfg *cfg = dev->config;
 	char mode_str[10] = {0};
-
-	data->common.mode = mode;
 
 	switch (mode) {
 	case MIT:
@@ -211,8 +215,9 @@ int mi_motor_set_mode(const struct device *dev, enum motor_mode mode)
 		break;
 	default:
 		LOG_DBG("Unknown motor mode: %d", mode);
-		break;
+		return -ENOSYS;
 	}
+	data->common.mode = mode;
 	struct can_frame frame = {0};
 	struct mi_can_id *mi_can_id = (struct mi_can_id *)&(frame.id);
 	mi_can_id->mi_msg_mode = Communication_Type_SetSingleParameter;
@@ -223,7 +228,9 @@ int mi_motor_set_mode(const struct device *dev, enum motor_mode mode)
 	memcpy(&frame.data[0], &index, 2);
 
 	frame.data[4] = (uint8_t)mode;
-	can_send_queued(cfg->common.phy, &frame);
+	if (send) {
+		can_send_queued(cfg->common.phy, &frame);
+	}
 
 	for (int i = 0; i < SIZE_OF_ARRAY(cfg->common.capabilities); i++) {
 		if (cfg->common.pid_datas[i]->pid_dev == NULL) {
@@ -240,6 +247,13 @@ int mi_motor_set_mode(const struct device *dev, enum motor_mode mode)
 		}
 	}
 	return 0;
+}
+
+int mi_motor_set_mode(const struct device *dev, enum motor_mode mode)
+{
+	struct mi_motor_data *data = dev->data;
+
+	return mi_motor_apply_mode(dev, mode, data->enabled);
 }
 
 static int get_motor_id(struct can_frame *frame)
@@ -275,6 +289,7 @@ static void mi_can_rx_handler(const struct device *can_dev, struct can_frame *fr
 	struct mi_can_id *can_id = (struct mi_can_id *)&(frame->id);
 	if (can_id->mi_msg_mode == Communication_Type_MotorFeedback) {
 		data->err = ((can_id->data) >> 8) & 0x3f;
+		data->online = true;
 		if (data->err) {
 			LOG_ERR("id:%d err:%d", id, data->err);
 		}
@@ -340,21 +355,11 @@ void mi_tx_data_handler(struct k_work *work)
 		struct mi_motor_data *data = motor_devices[i]->data;
 		const struct mi_motor_cfg *cfg = motor_devices[i]->config;
 		if (data->enabled) {
-			int can_id = get_can_id(motor_devices[i]);
 			if (data->missed_times > 600) {
 				LOG_ERR("Motor %s is not responding, setting it to offline.",
 					motor_devices[i]->name);
 				data->missed_times = 0;
-				// struct can_frame frame = {0};
-				// frame.flags = CAN_FRAME_IDE;
-				// frame.dlc = 8;
-				// struct mi_can_id *mi_can_id = (struct mi_can_id *)&(frame.id);
-				// mi_can_id->id = cfg->common.id;
-				// mi_can_id->mi_msg_mode = Communication_Type_MotorEnable;
-				// can_send_queued(cfg->common.phy, &frame);
-				// data->online = true;
-				// data->enabled = true;
-				// data->missed_times = 0;
+				data->online = false;
 			}
 			mi_motor_pack(motor_devices[i], tx_frame);
 
@@ -390,13 +395,6 @@ void mi_init_handler(struct k_work *work)
 			LOG_ERR("Error adding CAN filter (err %d)", err);
 		}
 	}
-	k_sleep(K_MSEC(100));
-
-	for (int i = 0; i < MOTOR_COUNT; i++) {
-		mi_motor_control(motor_devices[i], SET_ZERO);
-		k_sleep(K_MSEC(1));
-	}
-
 	k_timer_start(&mi_tx_timer, K_NO_WAIT, K_MSEC(3));
 	k_timer_user_data_set(&mi_tx_timer, &mi_tx_data_handle);
 }
@@ -449,7 +447,6 @@ int mi_set(const struct device *dev, motor_status_t *status)
 				struct pid_config params;
 				pid_get_params(cfg->common.pid_datas[i], &params);
 
-				data->common.mode = status->mode;
 				data->params.k_p = params.k_p;
 				data->params.k_d = params.k_d;
 				break;
@@ -463,9 +460,8 @@ int mi_set(const struct device *dev, motor_status_t *status)
 			LOG_ERR("Failed to set motor mode");
 			return -EIO;
 		}
-	} else {
-		return 0; // No mode change, no need to set
 	}
+	return 0;
 }
 
 DT_INST_FOREACH_STATUS_OKAY(MIMOTOR_INST)

--- a/drivers/motor/robstride/motor_rs.c
+++ b/drivers/motor/robstride/motor_rs.c
@@ -15,6 +15,8 @@
 
 LOG_MODULE_REGISTER(motor_rs, CONFIG_MOTOR_LOG_LEVEL);
 
+static int rs_motor_apply_mode(const struct device *dev, enum motor_mode mode, bool send);
+
 static float uint16_to_float(uint16_t x, float x_min, float x_max, int bits)
 {
 	float span = x_max - x_min;
@@ -83,30 +85,6 @@ int rs_init(const struct device *dev)
 			return -1;
 		}
 	}
-	k_sleep(K_MSEC(100));
-
-	for (int i = 0; i < MOTOR_COUNT; i++) {
-		const struct rs_motor_cfg *cfg =
-			(const struct rs_motor_cfg *)(motor_devices[i]->config);
-
-		if (cfg->auto_report) {
-			struct rs_can_id id = {
-				.master_id = cfg->common.rx_id,
-				.motor_id = cfg->common.tx_id,
-				.reserved = 0,
-				.msg_type = Communication_Type_MotorReport,
-			};
-			struct can_frame frame = {
-				.data = {0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x01, 0x00},
-				.dlc = 8,
-				.flags = CAN_FRAME_IDE,
-			};
-			frame.id = *(uint32_t *)&id;
-			can_send_queued(cfg->common.phy, &frame);
-			k_sleep(K_MSEC(1));
-		}
-	}
-
 	k_timer_start(&rs_tx_timer, K_NO_WAIT, K_MSEC(5));
 	return 0;
 }
@@ -127,6 +105,10 @@ void rs_motor_control(const struct device *dev, enum motor_cmd cmd)
 	};
 	switch (cmd) {
 	case ENABLE_MOTOR:
+		if (rs_motor_apply_mode(dev, data->common.mode, true) < 0) {
+			LOG_ERR("Failed to set motor mode before enabling");
+			return;
+		}
 		id.msg_type = Communication_Type_MotorStop;
 		frame.id = *(uint32_t *)&id;
 		frame.data[0] = 0x01;
@@ -143,6 +125,7 @@ void rs_motor_control(const struct device *dev, enum motor_cmd cmd)
 		frame.id = *(uint32_t *)&id;
 		can_send_queued(cfg->common.phy, &frame);
 		data->enabled = false;
+		data->online = false;
 		break;
 	case SET_ZERO:
 		id.msg_type = Communication_Type_SetPosZero;
@@ -157,7 +140,11 @@ void rs_motor_control(const struct device *dev, enum motor_cmd cmd)
 		frame.data[0] = 0x01;
 		can_send_queued(cfg->common.phy, &frame);
 		data->enabled = false;
+		data->online = false;
 		break;
+	default:
+		LOG_ERR("Unsupport motor command: %d", cmd);
+		return;
 	}
 }
 
@@ -199,7 +186,7 @@ static void rs_motor_pack(const struct device *dev, struct can_frame *frame)
 	return;
 }
 
-int rs_motor_set_mode(const struct device *dev, enum motor_mode mode)
+static int rs_motor_apply_mode(const struct device *dev, enum motor_mode mode, bool send)
 {
 
 	struct rs_motor_data *data = dev->data;
@@ -225,7 +212,9 @@ int rs_motor_set_mode(const struct device *dev, enum motor_mode mode)
 	memcpy(&frame.data[0], &index, 2);
 
 	frame.data[4] = (uint8_t)mode;
-	can_send_queued(cfg->common.phy, &frame);
+	if (send) {
+		can_send_queued(cfg->common.phy, &frame);
+	}
 
 	for (int i = 0; i < SIZE_OF_ARRAY(cfg->common.capabilities); i++) {
 		if (cfg->common.pid_datas[i]->pid_dev == NULL) {
@@ -233,8 +222,11 @@ int rs_motor_set_mode(const struct device *dev, enum motor_mode mode)
 			break;
 		}
 		if (strcmp(cfg->common.capabilities[i], mode_str) == 0) {
-			struct pid_config params;
-			pid_get_params(cfg->common.pid_datas[i], &params);
+			struct pid_config params = {0};
+			int ret = pid_get_params(cfg->common.pid_datas[i], &params);
+			if (ret != 0) {
+				return ret;
+			}
 
 			data->common.mode = mode;
 			data->params.k_p = params.k_p;
@@ -243,6 +235,13 @@ int rs_motor_set_mode(const struct device *dev, enum motor_mode mode)
 		}
 	}
 	return 0;
+}
+
+void rs_motor_set_mode(const struct device *dev, enum motor_mode mode)
+{
+	struct rs_motor_data *data = dev->data;
+
+	(void)rs_motor_apply_mode(dev, mode, data->enabled);
 }
 
 static void rs_can_rx_handler(const struct device *can_dev, struct can_frame *frame,
@@ -353,7 +352,7 @@ int rs_set(const struct device *dev, motor_status_t *status)
 		return -ENOSYS;
 	}
 	if (status->mode != data->common.mode) {
-		if (rs_motor_set_mode(dev, status->mode) < 0) {
+		if (rs_motor_apply_mode(dev, status->mode, data->enabled) < 0) {
 			LOG_ERR("Failed to set motor mode");
 			return -EIO;
 		}

--- a/drivers/motor/robstride/motor_rs.h
+++ b/drivers/motor/robstride/motor_rs.h
@@ -147,7 +147,7 @@ struct k_work_q rs_work_queue;
 int rs_set(const struct device *dev, motor_status_t *status);
 int rs_get(const struct device *dev, motor_status_t *status);
 void rs_motor_control(const struct device *dev, enum motor_cmd cmd);
-int rs_motor_set_mode(const struct device *dev, enum motor_mode mode);
+void rs_motor_set_mode(const struct device *dev, enum motor_mode mode);
 
 void rs_tx_isr_handler(struct k_timer *dummy);
 void rs_tx_data_handler(struct k_work *work);

--- a/drivers/motor/vesc/motor_vesc.c
+++ b/drivers/motor/vesc/motor_vesc.c
@@ -237,6 +237,10 @@ int vesc_set(const struct device *dev, motor_status_t *status)
 		vesc_motor_set_mode(dev, status->mode);
 	}
 
+	if (!data->enable) {
+		return 0;
+	}
+
 	struct can_frame frame = {0};
 	vesc_motor_pack(dev, &frame);
 	can_send_queued(cfg->common.phy, &frame);


### PR DESCRIPTION
## Summary

This PR tightens motor-driver startup semantics so motor devices do not emit enable or control traffic by default after power-on. Drivers now require an explicit `ENABLE_MOTOR` before sending active control frames.

Changes are split into four commits:

- `motor: guard queued CAN sends for unknown bus`
- `motor/dji: require manual enable before output`
- `motor: stop DM and LK boot-time enables`
- `motor: gate MI RS and VESC traffic on enable`

## Details

- DJI now has a separate software `enabled` state. Feedback marks the motor online, but does not authorize output. When not manually enabled, DJI frames pack zero current for that slot.
- DM no longer defaults `online/enable/enabled` to true and no longer auto-enables all motors from init. DM periodic transmit and direct set paths are gated by manual enable state.
- LK no longer auto-enables motors or submits PID writes during init. PID updates are sent only after enable, and the stale `pidupdate` index handling was fixed.
- MI and Robstride no longer send run-mode setup before manual enable. The “parameter frame” here is the `Communication_Type_SetSingleParameter` frame used to write `Run_mode`, not a target-control frame. It is now held until explicit enable or an already-enabled mode change.
- VESC now caches set targets while disabled and only sends after `ENABLE_MOTOR`.
- Common CAN queued send now rejects unregistered CAN devices before indexing the TX semaphore table.

## Validation

- `git diff --check HEAD~4..HEAD`
- `west build -p always -b dm_mc02 -s samples/motor/dm_demo -d build/motor_dm_manual_enable -- -DZEPHYR_EXTRA_MODULES=/Users/ttwards/Documents/zephyr_ws/mambo-review-motor`
- `west build -p always -b robomaster_board_c -s samples/motor/test_mi -d build/motor_mi_manual_enable -- -DZEPHYR_EXTRA_MODULES=/Users/ttwards/Documents/zephyr_ws/mambo-review-motor`
- `west build -p always -b dm_mc02 -s samples/motor/dji_m3508_demo -d build/motor_dji_manual_enable -- -DZEPHYR_EXTRA_MODULES=/Users/ttwards/Documents/zephyr_ws/mambo-review-motor -DEXTRA_CONF_FILE=/Users/ttwards/Documents/zephyr_ws/mambo-review-motor/build/no_sensor.conf`
- `west build -p always -b dm_mc02 -s samples/motor/rs_demo -d build/motor_rs_manual_enable -- -DZEPHYR_EXTRA_MODULES=/Users/ttwards/Documents/zephyr_ws/mambo-review-motor -DEXTRA_CONF_FILE=/Users/ttwards/Documents/zephyr_ws/mambo-review-motor/build/no_sensor.conf`
- `west build -p always -b dm_mc02 -s samples/motor/vesc_demo -d build/motor_vesc_manual_enable -- -DZEPHYR_EXTRA_MODULES=/Users/ttwards/Documents/zephyr_ws/mambo-review-motor -DEXTRA_CONF_FILE=/Users/ttwards/Documents/zephyr_ws/mambo-review-motor/build/no_sensor.conf`
