### PR TITLE
feat: bring up MC-02 USART1 ARES UART transport

### DIFF
--- a/Documents/updates/ares_uart_usart1_921600_update.md
+++ b/Documents/updates/ares_uart_usart1_921600_update.md
@@ -1,0 +1,159 @@
+<!--
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# ARES UART USART1 921600 Update
+
+Date: 2026-07-01
+Board: Damiao MC-02, STM32H723
+Test UART: USART1 on PA9/PA10
+Log UART: USART10 at 115200
+Host UART device: `/dev/cu.usbmodem00000000050C1`
+
+## Summary
+
+This update brings up the ARES UART interface on MC-02 USART1 and validates it
+with real ARES dual-protocol FUNC/REPL frames at 921600 baud. The test path does
+not bypass the protocol stack: the host sends FUNC frames, the board runs the
+sample `func_cb`, and the board sends REPL frames back through the UART
+interface.
+
+## Bugs Found
+
+- The communication sample hard-coded `DT_NODELABEL(usart6)`, while MC-02 test
+  hardware is wired to USART1.
+- `CONFIG_UART_ASYNC_API` was not enabled in the UART test build, causing
+  `uart_callback_set()` to fail with `-ENOSYS`.
+- STM32 async UART requires DMA. Without `dmas`/`dma-names`, `uart_tx()` failed
+  with `-ENODEV`.
+- STM32H7 async UART DMA rejects cached buffers. RX and TX initially failed with
+  `Rx/Tx buffer should be placed in a nocache memory region` and `-EFAULT`.
+- The UART driver created threads with `K_NO_WAIT` and then called
+  `k_thread_start()` again, which can restart an already started thread and led
+  to an MPU fault during bring-up.
+- UART thread stacks were declared as raw `k_thread_stack_t[]` members instead
+  of Zephyr kernel stack members.
+
+## Changes
+
+- The sample now honors `chosen { ares,uart = ...; }` before falling back to
+  `usart6`, so board-specific UART selection can be done in an overlay.
+- Added `samples/communication/ares_communication/boards/dm_mc02_usart1_921600.overlay`
+  for USART1 PA9/PA10 at 921600 baud with STM32H7 DMAMUX requests 42/41.
+- UART RX slab is placed in `__nocache`.
+- UART TX copies each outgoing `net_buf` into a dedicated `__nocache` DMA buffer
+  before calling `uart_tx()`.
+- UART exposes TX-complete callback support and interface caps/MTU so the dual
+  protocol can clear in-flight state when real UART TX completes.
+- Removed redundant `k_thread_start()` calls after `k_thread_create(..., K_NO_WAIT)`.
+- Changed UART stack members to `K_KERNEL_STACK_MEMBER`.
+
+## Build Commands
+
+Functional/log-enabled test:
+
+```sh
+west build -p always -b dm_mc02/stm32h723xx \
+  samples/communication/ares_communication \
+  -d build_uart_test -- \
+  -DDTC_OVERLAY_FILE="samples/communication/ares_communication/boards/dm_mc02.overlay;samples/communication/ares_communication/boards/dm_mc02_usart1_921600.overlay" \
+  -DCONFIG_UART_INTERFACE=y \
+  -DCONFIG_UART_ASYNC_API=y \
+  -DCONFIG_NOCACHE_MEMORY=y
+```
+
+Transport benchmark without application logging:
+
+```sh
+west build -p always -b dm_mc02/stm32h723xx \
+  samples/communication/ares_communication \
+  -d build_uart_test -- \
+  -DDTC_OVERLAY_FILE="samples/communication/ares_communication/boards/dm_mc02.overlay;samples/communication/ares_communication/boards/dm_mc02_usart1_921600.overlay" \
+  -DCONFIG_UART_INTERFACE=y \
+  -DCONFIG_UART_ASYNC_API=y \
+  -DCONFIG_NOCACHE_MEMORY=y \
+  -DCONFIG_LOG=n
+```
+
+Flash:
+
+```sh
+west flash -d build_uart_test --no-rebuild --runner openocd \
+  --config boards/damiao/dm_mc02/support/openocd.cfg
+```
+
+## Functional Validation
+
+- Board initialized `uart_protocol` successfully on USART1.
+- Board transmitted ARES heartbeat frames on USART1.
+- Host heartbeat frames kept `uart_protocol` online.
+- Host FUNC frame:
+
+```text
+ca fe 01 00 11 00 00 00 22 00 00 00 33 00 00 00 34 12
+```
+
+Board log confirmed:
+
+```text
+func_cb
+params: 11,22,33
+```
+
+## Performance
+
+All rows use 921600 baud, FUNC requests are 18 bytes, REPL replies are 10 bytes.
+RTT is measured at the host from FUNC write to matching REPL read. At overloaded
+rates, REPL request IDs wrap at 8 bits in the current protocol, so tail RTT is
+best read as queue/overload indication rather than precise per-frame latency.
+
+### Log Enabled
+
+The sample's `func_cb` logs two lines per incoming FUNC. USART10 logging at
+115200 saturated around 9.4 KiB/s and became a system-level bottleneck.
+
+| Target FPS | Sent FPS | Reply FPS | Success | Avg RTT ms | P95 RTT ms | P99 RTT ms | Max RTT ms |
+| ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| 500 | 500.0 | 500.0 | 100.00% | 1.03 | 1.15 | 1.72 | 3.34 |
+| 1000 | 1000.0 | 1000.0 | 100.00% | 1.03 | 1.13 | 1.33 | 3.65 |
+| 2000 | 1998.7 | 1989.0 | 99.52% | 8.21 | 128.78 | 129.20 | 131.88 |
+| 3000 | 2818.0 | 2777.3 | 98.56% | 16.07 | 86.65 | 170.87 | 343.31 |
+| 4000 | 2759.0 | 2721.0 | 98.62% | 23.31 | 103.72 | 198.97 | 331.67 |
+| 5000 | 2767.0 | 2733.7 | 98.80% | 17.27 | 97.50 | 169.64 | 271.34 |
+
+Practical log-enabled operating point: 1000 FUNC/REPL fps with low latency and
+no observed loss in the 3 s run. Higher rates still return many frames, but the
+log backend is saturated and tail latency rises sharply.
+
+### Log Disabled
+
+This removes application log traffic while keeping the real ARES UART
+FUNC/REPL path. The wire-rate request-side limit for 18-byte frames at 921600
+8N1 is about 5120 FUNC fps.
+
+| Target FPS | Sent FPS | Reply FPS | Success | Avg RTT ms | P50 RTT ms | P95 RTT ms | P99 RTT ms | Max RTT ms |
+| ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| 1000 | 979.7 | 969.3 | 98.95% | 22.93 | 0.93 | 256.85 | 257.17 | 573.82 |
+| 2000 | 2000.0 | 1977.3 | 98.87% | 19.65 | 0.89 | 128.93 | 256.88 | 384.85 |
+| 3000 | 3000.0 | 2824.0 | 94.13% | 113.50 | 86.08 | 341.76 | 342.50 | 512.89 |
+| 4000 | 4000.0 | 2948.0 | 73.70% | 386.33 | 384.53 | 896.55 | 1088.59 | 1345.09 |
+| 5000 | 5000.0 | 1898.3 | 37.97% | 952.40 | 914.41 | 1817.98 | 2021.38 | 2328.66 |
+| 6000 | 5996.3 | 1464.0 | 24.41% | 997.69 | 928.22 | 2254.06 | 2461.94 | 2803.09 |
+
+Practical log-disabled operating point: around 2000 FUNC/REPL fps for sustained
+testing with about 98.9% replies in this run. The maximum observed reply
+throughput was about 2948 REPL fps at a 4000 fps request target, but that mode
+is overloaded and drops roughly 26% of replies.
+
+The stable 2000 fps point corresponds to approximately 36.0 KiB/s of request
+frame bytes host-to-board and 19.3 KiB/s of reply frame bytes board-to-host,
+or about 55.3 KiB/s total protocol frame bytes across the full-duplex UART.
+
+## Remaining Bottleneck
+
+The UART transport is now functional at 921600, but the current dual-protocol
+FUNC reply path has only one in-flight reply buffer per function mapping. When
+FUNC frames arrive faster than UART TX completion can clear that in-flight bit,
+extra replies are intentionally skipped. Raising the loss-free ceiling will
+require queuing REPL frames or giving each pending reply its own buffer and
+request ID storage.

--- a/include/ares/interface/uart/uart.h
+++ b/include/ares/interface/uart/uart.h
@@ -16,8 +16,12 @@
 
 int ares_uart_init(struct AresInterface *interface);
 int ares_uart_send(struct AresInterface *interface, struct net_buf *buf);
+int ares_uart_send_with_callback(struct AresInterface *interface, struct net_buf *buf,
+				 ares_interface_tx_done_cb_t cb, void *user_data);
 int ares_uart_send_raw(struct AresInterface *interface, uint8_t *data, uint16_t len);
 struct net_buf *ares_uart_interface_alloc_buf(struct AresInterface *interface);
+uint32_t ares_uart_caps(struct AresInterface *interface);
+size_t ares_uart_mtu(struct AresInterface *interface);
 
 void ares_uart_init_dev(struct AresInterface *interface, const struct device *uart_dev);
 
@@ -41,21 +45,24 @@ struct AresUartInterface {
 	struct k_sem sem;
 
 	struct k_thread thread;
-	k_thread_stack_t thread_stack[ARES_UART_PROCESSING_THREAD_STACK_SIZE];
+	K_KERNEL_STACK_MEMBER(thread_stack, ARES_UART_PROCESSING_THREAD_STACK_SIZE);
 
 	struct k_msgq tx_msgq; // 发送消息队列
 	char __aligned(4) tx_msgq_buffer[sizeof(struct net_buf *) * ARES_UART_TX_QUEUE_SIZE];
-	struct k_sem tx_sem;                                              // 用于发送流控制的信号量
-	struct net_buf *current_tx_buf;                                   // 指向当前正在发送的buf
-	struct k_thread tx_thread;                                        // 发送线程的句柄
-	k_thread_stack_t tx_thread_stack[ARES_UART_TX_THREAD_STACK_SIZE]; // 发送线程的栈
+	struct k_sem tx_sem;            // 用于发送流控制的信号量
+	struct net_buf *current_tx_buf; // 指向当前正在发送的buf
+	struct k_thread tx_thread;      // 发送线程的句柄
+	K_KERNEL_STACK_MEMBER(tx_thread_stack, ARES_UART_TX_THREAD_STACK_SIZE); // 发送线程的栈
 };
 
 #define ARES_UART_INTERFACE_DEFINE(Interface_name)                                                 \
 	struct AresInterfaceAPI ares_uart_interface_api = {                                        \
 		.init = ares_uart_init,                                                            \
 		.send = ares_uart_send,                                                            \
+		.send_with_callback = ares_uart_send_with_callback,                                \
 		.send_raw = ares_uart_send_raw,                                                    \
+		.caps = ares_uart_caps,                                                            \
+		.mtu = ares_uart_mtu,                                                              \
 		.alloc_buf = ares_uart_interface_alloc_buf,                                        \
 	};                                                                                         \
 	struct AresUartInterface Internal_##Interface_name = {NULL};                               \

--- a/lib/ares/interface/uart/uart.c
+++ b/lib/ares/interface/uart/uart.c
@@ -6,6 +6,7 @@
 
 #include <zephyr/drivers/uart.h>
 #include <zephyr/kernel.h>
+#include <zephyr/linker/section_tags.h>
 #include <zephyr/logging/log.h>
 #include <zephyr/net_buf.h>
 
@@ -13,6 +14,7 @@
 #include "ares/interface/uart/uart.h"
 #include "zephyr/sys/ring_buffer.h"
 #include <ares/protocol/ares_protocol.h>
+#include <string.h>
 
 LOG_MODULE_REGISTER(ares_uart, LOG_LEVEL_INF); // 日志级别可以按需调整
 
@@ -21,8 +23,30 @@ LOG_MODULE_REGISTER(ares_uart, LOG_LEVEL_INF); // 日志级别可以按需调整
 #define ARES_UART_PROCESSING_THREAD_PRIORITY   K_PRIO_PREEMPT(5)
 #define ARES_UART_RX_INACTIVE_TIMEOUT          10
 
-NET_BUF_POOL_DEFINE(uart_net_buf_pool, 16, 128, 4, NULL); // 增加缓冲区数量和大小
-K_MEM_SLAB_DEFINE(uart_rx_slab, ARES_UART_BLOCK_SIZE, 8, 4);
+struct ares_uart_tx_meta {
+	ares_interface_tx_done_cb_t tx_done;
+	void *tx_user_data;
+};
+
+NET_BUF_POOL_DEFINE(uart_net_buf_pool, 16, 128, sizeof(struct ares_uart_tx_meta),
+		    NULL); // 增加缓冲区数量和大小
+K_MEM_SLAB_DEFINE_IN_SECT(uart_rx_slab, __nocache, ARES_UART_BLOCK_SIZE, 8, 4);
+
+static uint8_t __nocache __aligned(32) uart_tx_dma_buf[MAX_FRAME_PAYLOAD_SIZE];
+
+static void ares_uart_complete_tx(struct AresInterface *interface, struct net_buf *buf, int status)
+{
+	struct ares_uart_tx_meta *meta;
+
+	if (buf == NULL) {
+		return;
+	}
+
+	meta = net_buf_user_data(buf);
+	if (meta && meta->tx_done) {
+		meta->tx_done(interface, buf, status, meta->tx_user_data);
+	}
+}
 
 /**
  * @brief 发送一个数据包到队列中
@@ -35,10 +59,23 @@ K_MEM_SLAB_DEFINE(uart_rx_slab, ARES_UART_BLOCK_SIZE, 8, 4);
  */
 int ares_uart_send(struct AresInterface *interface, struct net_buf *buf)
 {
+	return ares_uart_send_with_callback(interface, buf, NULL, NULL);
+}
+
+int ares_uart_send_with_callback(struct AresInterface *interface, struct net_buf *buf,
+				 ares_interface_tx_done_cb_t cb, void *user_data)
+{
 	struct AresUartInterface *uart_if = interface->priv_data;
+	struct ares_uart_tx_meta *meta = net_buf_user_data(buf);
+
+	if (meta) {
+		meta->tx_done = cb;
+		meta->tx_user_data = user_data;
+	}
 
 	if (k_msgq_put(&uart_if->tx_msgq, &buf, K_NO_WAIT) != 0) {
 		LOG_ERR("TX message queue is full. Dropping packet!");
+		ares_uart_complete_tx(interface, buf, -ENOMEM);
 		net_buf_unref(buf);
 		return -ENOMEM;
 	}
@@ -56,12 +93,35 @@ int ares_uart_send_raw(struct AresInterface *interface, uint8_t *data, uint16_t 
 		LOG_ERR("uart_tx failed with error %d", err);
 		return -EIO;
 	}
+	return 0;
 }
 
 struct net_buf *ares_uart_interface_alloc_buf(struct AresInterface *interface)
 {
 	struct net_buf *buf = net_buf_alloc(&uart_net_buf_pool, K_NO_WAIT);
+	if (buf) {
+		struct ares_uart_tx_meta *meta = net_buf_user_data(buf);
+		if (meta) {
+			meta->tx_done = NULL;
+			meta->tx_user_data = NULL;
+		}
+	}
 	return buf;
+}
+
+uint32_t ares_uart_caps(struct AresInterface *interface)
+{
+	ARG_UNUSED(interface);
+
+	return ARES_INTERFACE_CAP_STREAM | ARES_INTERFACE_CAP_TX_COMPLETE |
+	       ARES_INTERFACE_CAP_TX_QUEUE;
+}
+
+size_t ares_uart_mtu(struct AresInterface *interface)
+{
+	ARG_UNUSED(interface);
+
+	return MAX_FRAME_PAYLOAD_SIZE;
 }
 
 /**
@@ -80,11 +140,20 @@ static void ares_uart_tx_thread_entry(void *p1, void *p2, void *p3)
 	while (1) {
 		k_msgq_get(&uart_if->tx_msgq, &buf, K_FOREVER);
 		k_sem_take(&uart_if->tx_sem, K_FOREVER);
+		if (buf->len > sizeof(uart_tx_dma_buf)) {
+			LOG_ERR("UART frame too large for DMA buffer: %u", buf->len);
+			ares_uart_complete_tx(interface, buf, -EMSGSIZE);
+			net_buf_unref(buf);
+			k_sem_give(&uart_if->tx_sem);
+			continue;
+		}
+		memcpy(uart_tx_dma_buf, buf->data, buf->len);
 		uart_if->current_tx_buf = buf;
-		err = uart_tx(uart_if->uart_dev, buf->data, buf->len, SYS_FOREVER_US);
+		err = uart_tx(uart_if->uart_dev, uart_tx_dma_buf, buf->len, SYS_FOREVER_US);
 		if (err != 0) {
 			LOG_ERR("uart_tx failed with error %d, even with flow control!", err);
 			k_sem_give(&uart_if->tx_sem);
+			ares_uart_complete_tx(interface, uart_if->current_tx_buf, -EIO);
 			net_buf_unref(uart_if->current_tx_buf);
 			uart_if->current_tx_buf = NULL;
 		}
@@ -101,6 +170,7 @@ static void uart_callback(const struct device *dev, struct uart_event *evt, void
 	/* --- TX 事件处理 --- */
 	case UART_TX_DONE:
 		if (uart_if->current_tx_buf != NULL) {
+			ares_uart_complete_tx(uart_if->interface, uart_if->current_tx_buf, 0);
 			net_buf_unref(uart_if->current_tx_buf);
 			uart_if->current_tx_buf = NULL;
 		}
@@ -110,6 +180,8 @@ static void uart_callback(const struct device *dev, struct uart_event *evt, void
 	case UART_TX_ABORTED:
 		LOG_WRN("UART TX aborted");
 		if (uart_if->current_tx_buf != NULL) {
+			ares_uart_complete_tx(uart_if->interface, uart_if->current_tx_buf,
+					      -ECANCELED);
 			net_buf_unref(uart_if->current_tx_buf);
 			uart_if->current_tx_buf = NULL;
 		}
@@ -178,6 +250,7 @@ void ares_uart_thread_entry(void *p1, void *p2, void *p3)
 void ares_uart_init_dev(struct AresInterface *interface, const struct device *uart_dev)
 {
 	struct AresUartInterface *uart_if = interface->priv_data;
+	uart_if->interface = interface;
 	uart_if->uart_dev = (struct device *)uart_dev;
 }
 
@@ -185,6 +258,7 @@ void ares_uart_init_dev(struct AresInterface *interface, const struct device *ua
 int ares_uart_init(struct AresInterface *interface)
 {
 	struct AresUartInterface *uart_if = interface->priv_data;
+	uart_if->interface = interface;
 
 	if (!device_is_ready(uart_if->uart_dev)) {
 		LOG_ERR("UART device not ready");
@@ -215,7 +289,6 @@ int ares_uart_init(struct AresInterface *interface)
 			(void *)interface, NULL, NULL, ARES_UART_PROCESSING_THREAD_PRIORITY, 0,
 			K_NO_WAIT);
 	k_thread_name_set(&uart_if->thread, "ares_uart_rx");
-	k_thread_start(&uart_if->thread);
 
 	/* --- 新增: 初始化 TX 部分 --- */
 	uart_if->current_tx_buf = NULL;
@@ -228,7 +301,6 @@ int ares_uart_init(struct AresInterface *interface)
 			(void *)interface, NULL, NULL, ARES_UART_PROCESSING_THREAD_PRIORITY, 0,
 			K_NO_WAIT);
 	k_thread_name_set(&uart_if->tx_thread, "ares_uart_tx");
-	k_thread_start(&uart_if->tx_thread);
 
 	LOG_INF("Ares UART Interface initialized with TX queue.");
 	return 0;

--- a/samples/communication/ares_communication/boards/dm_mc02.conf
+++ b/samples/communication/ares_communication/boards/dm_mc02.conf
@@ -1,0 +1,12 @@
+# SPDX-License-Identifier: Apache-2.0
+
+# dm_mc02 uses USART10 as the debug console, so keep this sample focused on USB bulk.
+CONFIG_UART_INTERFACE=n
+
+CONFIG_LOG=y
+CONFIG_CONSOLE=y
+CONFIG_UART_CONSOLE=y
+CONFIG_LOG_BACKEND_UART=y
+
+CONFIG_SENSOR=n
+CONFIG_BMI08X=n

--- a/samples/communication/ares_communication/boards/dm_mc02.overlay
+++ b/samples/communication/ares_communication/boards/dm_mc02.overlay
@@ -1,0 +1,9 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+zephyr_udc0: &usbotg_hs {
+	pinctrl-0 = <&usb_otg_hs_dm_pa11 &usb_otg_hs_dp_pa12>;
+	pinctrl-names = "default";
+	status = "okay";
+};

--- a/samples/communication/ares_communication/boards/dm_mc02_usart1_921600.overlay
+++ b/samples/communication/ares_communication/boards/dm_mc02_usart1_921600.overlay
@@ -1,0 +1,19 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	chosen {
+		ares,uart = &usart1;
+	};
+};
+
+&usart1 {
+	status = "okay";
+	pinctrl-0 = <&usart1_tx_pa9 &usart1_rx_pa10>;
+	pinctrl-names = "default";
+	current-speed = <921600>;
+	dmas = <&dmamux1 3 42 (STM32_DMA_PERIPH_TX | STM32_DMA_PRIORITY_HIGH)>,
+	       <&dmamux1 4 41 (STM32_DMA_PERIPH_RX | STM32_DMA_PRIORITY_HIGH)>;
+	dma-names = "tx", "rx";
+};

--- a/samples/communication/ares_communication/src/main.c
+++ b/samples/communication/ares_communication/src/main.c
@@ -3,7 +3,9 @@
 #include <zephyr/logging/log.h>
 #include <zephyr/net_buf.h>
 #include <ares/interface/usb/usb_bulk.h>
+#if IS_ENABLED(CONFIG_UART_INTERFACE)
 #include <ares/interface/uart/uart.h>
+#endif
 #include <ares/protocol/dual/dual_protocol.h>
 #include <ares/ares_comm.h>
 
@@ -11,15 +13,25 @@
 
 LOG_MODULE_REGISTER(main_app, LOG_LEVEL_INF);
 
+#if IS_ENABLED(CONFIG_UART_INTERFACE)
+#if DT_HAS_CHOSEN(ares_uart)
+#define UART_DEV DT_CHOSEN(ares_uart)
+#else
 #define UART_DEV DT_NODELABEL(usart6)
+#endif
 static const struct device *uart_dev = DEVICE_DT_GET(UART_DEV);
+#endif
 
 DUAL_PROPOSE_PROTOCOL_DEFINE(dual_protocol);
+#if IS_ENABLED(CONFIG_UART_INTERFACE)
 DUAL_PROPOSE_PROTOCOL_DEFINE(uart_protocol);
+#endif
 // 建议对UART使用CRC校验
 // DUAL_PROPOSE_PROTOCOL_DEFINE_CRC(uart_protocol);
 ARES_BULK_INTERFACE_DEFINE(usb_bulk_interface);
+#if IS_ENABLED(CONFIG_UART_INTERFACE)
 ARES_UART_INTERFACE_DEFINE(uart_interface);
+#endif
 
 int cnt = 0;
 int func_cb(uint32_t param1, uint32_t param2, uint32_t param3)
@@ -45,6 +57,7 @@ int main(void)
 {
 	LOG_INF("ARES USB Bulk & UART device is ready.");
 
+#if IS_ENABLED(CONFIG_UART_INTERFACE)
 	// Initialize UART interface
 	ares_uart_init_dev(&uart_interface, uart_dev);
 	int err_uart = ares_bind_interface(&uart_interface, &uart_protocol);
@@ -53,6 +66,7 @@ int main(void)
 	} else {
 		LOG_INF("ARES UART interface initialized successfully");
 	}
+#endif
 
 	// Initialize USB bulk interface
 	int err_usb = ares_bind_interface(&usb_bulk_interface, &dual_protocol);
@@ -68,10 +82,12 @@ int main(void)
 	sync_table_t *usb_pack =
 		dual_sync_add(&dual_protocol, 0x1, test, sizeof(test), (dual_trans_cb_t)sync_cb);
 
+#if IS_ENABLED(CONFIG_UART_INTERFACE)
 	dual_ret_cb_set(&uart_protocol, (dual_func_ret_cb_t)func_ret_cb);
 	dual_func_add(&uart_protocol, 0x1, (dual_trans_func_t)func_cb);
 	sync_table_t *uart_pack =
 		dual_sync_add(&uart_protocol, 0x1, test, sizeof(test), (dual_trans_cb_t)sync_cb);
+#endif
 
 	LOG_INF("ARES Dual Interface (USB Bulk + UART) device is ready.");
 
@@ -81,6 +97,7 @@ int main(void)
 	while (1) {
 		k_sleep(K_MSEC(1000));
 
+#if IS_ENABLED(CONFIG_UART_INTERFACE)
 		// Send data through both interfaces alternately
 		if (cnt % 2 == 0) {
 			// Send through USB
@@ -97,6 +114,13 @@ int main(void)
 				LOG_INF("Data sent via UART: %d", cnt);
 			}
 		}
+#else
+		if (err_usb == 0) {
+			dual_func_call(&dual_protocol, 0x1, 0x1, 0x2, cnt);
+			dual_sync_flush(&dual_protocol, usb_pack);
+			LOG_INF("Data sent via USB: %d", cnt);
+		}
+#endif
 		cnt++;
 	}
 


### PR DESCRIPTION
## 描述

在 MC-02 上 bring up ARES UART transport，并为 USART1 PA9/PA10 @ 921600 添加可复现测试配置和性能文档。

这次修改修复了 UART async DMA bring-up 中暴露的真实问题：sample UART 口硬编码、STM32 async UART 缺 DMA、DMA buffer 不在 nocache、UART 线程重复 start、以及 stack member 声明方式不符合 Zephyr kernel stack 用法。验证路径使用真实 ARES dual-protocol FUNC/REPL 帧，没有绕过协议栈。

## 改动类型

- [x] 🐛 Bug 修复
- [x] ✨ 新功能
- [x] 📝 文档更新
- [ ] 🎨 代码格式/风格调整
- [ ] ♻️ 代码重构
- [x] ⚡ 性能优化
- [x] ✅ 测试相关
- [x] 🔧 构建/工具相关

## 相关 Issue

N/A

## 测试

- [x] 代码通过所有 pre-commit 检查
- [x] 在以下开发板上测试通过：
  - [ ] Robomaster Board C
  - [ ] Robomaster Board A
  - [x] DM MC02
  - [ ] 其他：___________

本地验证：

- `pre-commit run --files` on the 7 PR files: passed.
- Build and flash, log-enabled functional firmware:
  - `CONFIG_UART_INTERFACE=y`
  - `CONFIG_UART_ASYNC_API=y`
  - `CONFIG_NOCACHE_MEMORY=y`
  - USART1 @ 921600 using `dm_mc02_usart1_921600.overlay`
- Build and flash, transport benchmark firmware:
  - same UART config plus `CONFIG_LOG=n`
- Hardware protocol validation:
  - board transmitted ARES heartbeat frames on USART1
  - host heartbeat frames kept `uart_protocol` online
  - host FUNC frame triggered board `func_cb`
  - board log confirmed `params: 11,22,33`
- Stress/performance testing at 921600 baud:
  - log-enabled: stable 1000 FUNC/REPL fps with 100% replies in the run
  - log-disabled: practical sustained point around 2000 fps with about 98.9% replies
  - overloaded maximum observed reply throughput about 2948 REPL fps at 4000 fps request target

## 检查清单

- [x] 我的代码遵循项目的编码规范
- [x] 我已经进行了自我审查
- [x] 我已经添加了必要的注释，特别是在难以理解的地方
- [x] 我已经更新了相关文档
- [ ] 我的改动没有产生新的警告
- [x] 我已经添加了测试来证明我的修复有效或新功能正常工作
- [ ] 新增和现有的单元测试在本地都通过
- [x] 所有文件都包含 SPDX 许可证头

说明：本地 build 仍会出现既有的 `DUAL_PROPOSE_PROTOCOL_DEFINE` missing-braces warning；本 PR 未处理该既有 warning。项目当前没有为这一路径新增单元测试，验证以硬件 FUNC/REPL 压测为主。

## 截图/日志

Functional test sent this FUNC frame from host:

```text
ca fe 01 00 11 00 00 00 22 00 00 00 33 00 00 00 34 12
```

Board log:

```text
func_cb
params: 11,22,33
```

Performance details are documented in:

`Documents/updates/ares_uart_usart1_921600_update.md`

## 其他说明

This PR targets `usb/ares-transport-update` because the UART transport fixes build on the ARES interface callback/caps work from the USB transport update branch.
