### PR TITLE
fix: repair ARES USB reconnect transport

### DIFF
--- a/Documents/updates/ares_usb_transport_update.md
+++ b/Documents/updates/ares_usb_transport_update.md
@@ -1,3 +1,5 @@
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+
 # ARES USB Transport Update
 
 Date: 2026-07-01

--- a/Documents/updates/ares_usb_transport_update.md
+++ b/Documents/updates/ares_usb_transport_update.md
@@ -1,0 +1,148 @@
+# ARES USB Transport Update
+
+Date: 2026-07-01
+Board under test: dm_mc02 / STM32H723
+USB device: ARES Bulk Interface Async, full-speed USB, VID:PID 1209:0001
+
+## Summary
+
+This update fixes the ARES USB bulk transport and dual protocol reconnect path. The
+main symptom was that the USB endpoints could still receive host frames while the
+protocol state stayed offline or the reply path stayed permanently busy after a
+host disconnect/reconnect.
+
+No benchmark-only firmware hooks are part of this update. The final validation was
+done on the normal `samples/communication/ares_communication` application.
+
+## Root Cause
+
+The old USB path treated `USBD_STATE_CONFIGURED` as the main source of truth for
+the protocol `CONNECTED` event. In practice, the Zephyr USB class `enable()`
+callback is the reliable point where the interface has been enabled and the first
+bulk OUT transfer can be submitted.
+
+There was also a second reconnect bug in the dual protocol TX path. The old
+implementation used mutex-style send ownership. After a host disconnect, an IN
+transfer could be left without a normal completion path. The board continued to
+receive and parse FUNC frames, but the matching reply path stayed marked busy, so
+later FUNC replies were suppressed.
+
+## Old Architecture
+
+- USB protocol connection was driven mostly by USB device state messages.
+- Bulk OUT submission and protocol online state were loosely coupled.
+- Reply and sync sends used a lock-like ownership model.
+- Disconnect cleanup cleared the backup queue, but did not clear all in-flight
+  FUNC/SYNC send state.
+- Reconnecting the host could leave the device in a split-brain state:
+  - OUT endpoint and parser were active.
+  - Protocol online/reply state could remain stale.
+  - Host could send frames but receive no replies.
+
+## New Architecture
+
+- USB class `enable()` first marks the interface enabled, then submits the initial
+  bulk OUT buffer.
+- The protocol receives `ARES_PROTOCOL_EVENT_CONNECTED` only after that OUT
+  submission succeeds.
+- A dedicated USB connected bit deduplicates `CONNECTED` and `DISCONNECTED`
+  events from class callbacks and USB state messages.
+- USB class `disable()`, reset, and suspend all flow through the same disconnect
+  state helper.
+- The ARES interface API now exposes TX completion callbacks and simple transport
+  capabilities.
+- USB bulk stores the TX completion callback in `net_buf` user data and calls it
+  from IN completion.
+- Dual protocol FUNC/SYNC sends use atomic `DUAL_TX_IN_FLIGHT` state that is
+  cleared by TX completion.
+- Offline/reconnect cleanup now clears:
+  - FUNC in-flight state.
+  - SYNC in-flight state.
+  - FUNC reply backup queue.
+  - FUNC backup count.
+
+The intended state model is:
+
+1. USB class enable succeeds.
+2. Initial OUT buffer is queued.
+3. Protocol is marked connected.
+4. Protocol sends use TX completion to release in-flight state.
+5. Disconnect/reconnect cleanup always resets stale TX state before going online
+   again.
+
+## Files Changed
+
+- `include/ares/interface/ares_interface.h`
+- `lib/ares/interface/ares_interface.h`
+- `include/ares/interface/usb/usb_bulk.h`
+- `lib/ares/interface/usb/usb_bulk.h`
+- `include/ares/protocol/dual/dual_protocol.h`
+- `lib/ares/interface/usb/usb_bulk.c`
+- `lib/ares/protocol/dual/dual_protocol.c`
+
+## Validation
+
+Build:
+
+```sh
+west build -d build
+```
+
+Flash:
+
+```sh
+west flash -d build --no-rebuild --runner openocd --config mambo/boards/damiao/dm_mc02/support/openocd.cfg
+```
+
+Startup log after reset showed the expected class-driven connection path:
+
+```text
+ares_usb_bulk_async: Enable ARES Bulk interface
+dual_protocol: dual_protocol Connection established due to event.
+```
+
+Three consecutive host reconnect tests completed successfully. Before this fix,
+later runs could drop to `replies=0` while the board still logged incoming
+`func_cb` calls.
+
+```text
+Run 1: sent=45949 replies=45449 send_fps=9189.8 reply_fps_over_send=9089.8
+Run 2: sent=46238 replies=45819 send_fps=9247.6 reply_fps_over_send=9163.8
+Run 3: sent=46039 replies=45626 send_fps=9207.8 reply_fps_over_send=9125.2
+```
+
+## Performance Data
+
+These numbers measure the normal ARES protocol path, not raw USB bulk maximum
+throughput. The tested application also still emits serial logs and periodic
+application traffic.
+
+Best observed exec/reply rate:
+
+- Host-to-device exec send rate: 9247.6 frames/s.
+- Device-to-host reply rate during send window: 9163.8 frames/s.
+- Exec frame payload on the wire: 18 bytes.
+- Reply frame payload on the wire: 10 bytes.
+- Approximate effective protocol payload throughput:
+  - OUT: 162.6 KiB/s.
+  - IN replies: 89.5 KiB/s.
+  - Combined: 252 KiB/s, about 2.06 Mbit/s.
+
+Round-trip latency for single `exec -> reply` calls:
+
+- Typical RTT: 0.28 ms to 0.36 ms.
+- Average RTT: 0.30 ms to 0.39 ms.
+- p95 RTT: 0.44 ms to 0.64 ms.
+- p99 RTT: 0.56 ms to 1.12 ms.
+- Observed max RTT: 1.4 ms to 3.8 ms.
+
+For application budgeting, `1 ms` is a conservative round-trip target for the
+current full-speed USB ARES protocol path.
+
+## Notes
+
+- The board enumerated as full-speed USB during the test.
+- The temporary USB bulk benchmark and UART diagnostic sample directories were
+  deleted and are not part of this update.
+- Raw USB bulk throughput can be higher than the protocol numbers above, but the
+  protocol numbers are the relevant data for current ARES exec/reply behavior.

--- a/include/ares/interface/ares_interface.h
+++ b/include/ares/interface/ares_interface.h
@@ -5,6 +5,7 @@
 #include <stddef.h>
 #include <stdbool.h>
 #include <zephyr/net_buf.h>
+#include <zephyr/sys/util.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -12,6 +13,19 @@ extern "C" {
 
 struct AresProtocol;
 struct AresInterface;
+
+typedef void (*ares_interface_tx_done_cb_t)(struct AresInterface *interface,
+					    struct net_buf *buf, int status,
+					    void *user_data);
+
+enum AresInterfaceCaps {
+	ARES_INTERFACE_CAP_STREAM = BIT(0),
+	ARES_INTERFACE_CAP_PACKET = BIT(1),
+	ARES_INTERFACE_CAP_ZERO_COPY = BIT(2),
+	ARES_INTERFACE_CAP_TX_COMPLETE = BIT(3),
+	ARES_INTERFACE_CAP_TX_QUEUE = BIT(4),
+	ARES_INTERFACE_CAP_ETHERNET_FRAME = BIT(5),
+};
 
 /**
  * @brief API that an interface must implement.
@@ -22,13 +36,15 @@ struct AresInterface;
  */
 struct AresInterfaceAPI {
 	int (*send)(struct AresInterface *interface, struct net_buf *buf);
-	int (*send_with_lock)(struct AresInterface *interface, struct net_buf *buf,
-			      struct k_mutex *mutex);
+	int (*send_with_callback)(struct AresInterface *interface, struct net_buf *buf,
+				  ares_interface_tx_done_cb_t cb, void *user_data);
 	int (*send_raw)(struct AresInterface *interface, uint8_t *data, uint16_t len);
 
 	int (*connect)(struct AresInterface *interface);
 	int (*disconnect)(struct AresInterface *interface);
 	bool (*is_connected)(struct AresInterface *interface);
+	uint32_t (*caps)(struct AresInterface *interface);
+	size_t (*mtu)(struct AresInterface *interface);
 
 	struct net_buf *(*alloc_buf)(struct AresInterface *interface);
 	struct net_buf *(*alloc_buf_with_data)(struct AresInterface *interface, void *data,

--- a/include/ares/interface/ares_interface.h
+++ b/include/ares/interface/ares_interface.h
@@ -14,9 +14,8 @@ extern "C" {
 struct AresProtocol;
 struct AresInterface;
 
-typedef void (*ares_interface_tx_done_cb_t)(struct AresInterface *interface,
-					    struct net_buf *buf, int status,
-					    void *user_data);
+typedef void (*ares_interface_tx_done_cb_t)(struct AresInterface *interface, struct net_buf *buf,
+					    int status, void *user_data);
 
 enum AresInterfaceCaps {
 	ARES_INTERFACE_CAP_STREAM = BIT(0),

--- a/include/ares/interface/usb/usb_bulk.h
+++ b/include/ares/interface/usb/usb_bulk.h
@@ -13,8 +13,10 @@ int ares_usbd_write(struct AresInterface *interface, struct net_buf *buf);
 struct net_buf *ares_interface_alloc_buf(struct AresInterface *interface);
 struct net_buf *ares_interface_alloc_buf_with_data(struct AresInterface *interface, void *data,
 						   size_t len);
-int ares_usbd_write_with_lock(struct AresInterface *interface, struct net_buf *buf,
-			      struct k_mutex *mutex);
+int ares_usbd_write_with_callback(struct AresInterface *interface, struct net_buf *buf,
+				  ares_interface_tx_done_cb_t cb, void *user_data);
+uint32_t ares_usbd_caps(struct AresInterface *interface);
+size_t ares_usbd_mtu(struct AresInterface *interface);
 
 struct AresBulkInterface {
 	struct AresInterface *interface;
@@ -32,7 +34,9 @@ struct AresBulkInterface {
 	struct AresInterfaceAPI ares_bulk_interface_api = {                                        \
 		.init = ares_usbd_init,                                                            \
 		.send = ares_usbd_write,                                                           \
-		.send_with_lock = ares_usbd_write_with_lock,                                       \
+		.send_with_callback = ares_usbd_write_with_callback,                               \
+		.caps = ares_usbd_caps,                                                            \
+		.mtu = ares_usbd_mtu,                                                              \
 		.alloc_buf = ares_interface_alloc_buf,                                             \
 		.alloc_buf_with_data = ares_interface_alloc_buf_with_data,                         \
 	};                                                                                         \

--- a/include/ares/protocol/dual/dual_protocol.h
+++ b/include/ares/protocol/dual/dual_protocol.h
@@ -94,6 +94,8 @@ enum frame_type {
 #define SYNC_PACK_STATUS_WRITE BIT(1)
 #define SYNC_PACK_STATUS_DONE  BIT(2)
 
+#define DUAL_TX_IN_FLIGHT 0
+
 #define GET_8BITS(buf, n_byte)  (*(uint8_t *)(buf + n_byte))
 #define GET_16BITS(buf, n_byte) (*(uint16_t *)(buf + n_byte))
 #define GET_32BITS(buf, n_byte) (*(uint32_t *)(buf + n_byte))
@@ -116,7 +118,7 @@ struct sync_pack {
 	dual_trans_cb_t cb;
 	uint8_t *buf;
 
-	struct k_mutex mutex;
+	atomic_t tx_state;
 };
 
 struct id_mapping {
@@ -127,7 +129,7 @@ struct id_mapping {
 	uint32_t arg3;
 	uint16_t req_id;
 
-	struct k_mutex mutex;
+	atomic_t tx_state;
 	__aligned(4) uint8_t buf[REPL_FRAME_LENGTH + 2]; // +2 for potential CRC16
 };
 

--- a/lib/ares/interface/ares_interface.h
+++ b/lib/ares/interface/ares_interface.h
@@ -5,6 +5,7 @@
 #include <stddef.h>
 #include <stdbool.h>
 #include <zephyr/net_buf.h>
+#include <zephyr/sys/util.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -12,6 +13,19 @@ extern "C" {
 
 struct AresProtocol;
 struct AresInterface;
+
+typedef void (*ares_interface_tx_done_cb_t)(struct AresInterface *interface,
+					    struct net_buf *buf, int status,
+					    void *user_data);
+
+enum AresInterfaceCaps {
+	ARES_INTERFACE_CAP_STREAM = BIT(0),
+	ARES_INTERFACE_CAP_PACKET = BIT(1),
+	ARES_INTERFACE_CAP_ZERO_COPY = BIT(2),
+	ARES_INTERFACE_CAP_TX_COMPLETE = BIT(3),
+	ARES_INTERFACE_CAP_TX_QUEUE = BIT(4),
+	ARES_INTERFACE_CAP_ETHERNET_FRAME = BIT(5),
+};
 
 /**
  * @brief API that an interface must implement.
@@ -22,13 +36,15 @@ struct AresInterface;
  */
 struct AresInterfaceAPI {
 	int (*send)(struct AresInterface *interface, struct net_buf *buf);
-	int (*send_with_lock)(struct AresInterface *interface, struct net_buf *buf,
-			      struct k_mutex *mutex);
+	int (*send_with_callback)(struct AresInterface *interface, struct net_buf *buf,
+				  ares_interface_tx_done_cb_t cb, void *user_data);
 	int (*send_raw)(struct AresInterface *interface, uint8_t *data, uint16_t len);
 
 	int (*connect)(struct AresInterface *interface);
 	int (*disconnect)(struct AresInterface *interface);
 	bool (*is_connected)(struct AresInterface *interface);
+	uint32_t (*caps)(struct AresInterface *interface);
+	size_t (*mtu)(struct AresInterface *interface);
 
 	struct net_buf *(*alloc_buf)(struct AresInterface *interface);
 	struct net_buf *(*alloc_buf_with_data)(struct AresInterface *interface, void *data,

--- a/lib/ares/interface/ares_interface.h
+++ b/lib/ares/interface/ares_interface.h
@@ -14,9 +14,8 @@ extern "C" {
 struct AresProtocol;
 struct AresInterface;
 
-typedef void (*ares_interface_tx_done_cb_t)(struct AresInterface *interface,
-					    struct net_buf *buf, int status,
-					    void *user_data);
+typedef void (*ares_interface_tx_done_cb_t)(struct AresInterface *interface, struct net_buf *buf,
+					    int status, void *user_data);
 
 enum AresInterfaceCaps {
 	ARES_INTERFACE_CAP_STREAM = BIT(0),

--- a/lib/ares/interface/usb/usb_bulk.c
+++ b/lib/ares/interface/usb/usb_bulk.c
@@ -45,6 +45,7 @@ static struct AresInterface *ares_interface;
 #define ARES_IF_FUNCTION_ENABLED     0
 #define ARES_IF_FUNCTION_OUT_ENGAGED 1
 #define ARES_IF_FUNCTION_IN_ENGAGED  2
+#define ARES_IF_FUNCTION_CONNECTED   3
 
 /* === USB Device and Descriptor Definitions === */
 
@@ -67,6 +68,7 @@ USBD_CONFIGURATION_DEFINE(ares_hs_config, attributes, 250, &hs_cfg_desc);
 
 // Forward declaration
 struct usbd_class_data *ares_if_class_data;
+static void ares_usbd_protocol_event(enum AresProtocolEvent event);
 
 struct ares_if_desc {
 	struct usb_if_descriptor if0;
@@ -83,6 +85,38 @@ struct ares_if_data {
 	const struct usb_desc_header **const hs_desc;
 	atomic_t state;
 };
+
+struct ares_udc_buf_info {
+	struct udc_buf_info udc_buf_info;
+	ares_interface_tx_done_cb_t tx_done;
+	void *tx_user_data;
+};
+
+static void ares_usbd_set_connected(struct usbd_class_data *const c_data, bool connected)
+{
+	struct ares_if_data *data;
+
+	if (c_data == NULL) {
+		return;
+	}
+
+	data = usbd_class_get_private(c_data);
+	if (data == NULL) {
+		return;
+	}
+
+	if (connected) {
+		if (!atomic_test_bit(&data->state, ARES_IF_FUNCTION_ENABLED)) {
+			return;
+		}
+
+		if (!atomic_test_and_set_bit(&data->state, ARES_IF_FUNCTION_CONNECTED)) {
+			ares_usbd_protocol_event(ARES_PROTOCOL_EVENT_CONNECTED);
+		}
+	} else if (atomic_test_and_clear_bit(&data->state, ARES_IF_FUNCTION_CONNECTED)) {
+		ares_usbd_protocol_event(ARES_PROTOCOL_EVENT_DISCONNECTED);
+	}
+}
 
 static uint8_t ares_if_get_bulk_out(struct usbd_class_data *const c_data)
 {
@@ -166,6 +200,10 @@ static int ares_if_request_handler(struct usbd_class_data *const c_data, struct 
 
 	if (ep == ares_if_get_bulk_in(c_data)) {
 		atomic_clear_bit(&data->state, ARES_IF_FUNCTION_IN_ENGAGED);
+		struct ares_udc_buf_info *buf_info = net_buf_user_data(buf);
+		if (buf_info && buf_info->tx_done) {
+			buf_info->tx_done(ares_interface, buf, err_code, buf_info->tx_user_data);
+		}
 		net_buf_unref(buf);
 
 		/*
@@ -233,24 +271,36 @@ static void *ares_if_get_desc(struct usbd_class_data *const c_data, const enum u
 static void ares_if_enable(struct usbd_class_data *const c_data)
 {
 	struct ares_if_data *data = usbd_class_get_private(c_data);
+	int err;
+
 	LOG_INF("Enable ARES Bulk interface");
 	if (atomic_test_and_set_bit(&data->state, ARES_IF_FUNCTION_ENABLED)) {
 		return;
 	}
-	if (ares_if_submit_bulk_out(c_data) != 0) {
+	err = ares_if_submit_bulk_out(c_data);
+	if (err != 0) {
 		LOG_ERR("Failed to submit initial bulk OUT request on enable");
+		return;
 	}
+
+	ares_usbd_set_connected(c_data, true);
 }
 
 static void ares_if_disable(struct usbd_class_data *const c_data)
 {
 	struct ares_if_data *data = usbd_class_get_private(c_data);
+	struct net_buf *buf;
+
 	LOG_INF("Disable ARES Bulk interface");
+	ares_usbd_set_connected(c_data, false);
+
 	atomic_clear_bit(&data->state, ARES_IF_FUNCTION_ENABLED);
 	atomic_clear_bit(&data->state, ARES_IF_FUNCTION_IN_ENGAGED);
 	atomic_clear_bit(&data->state, ARES_IF_FUNCTION_OUT_ENGAGED);
-	/* Additionally, we should purge the queue to release any pending buffers */
-	k_msgq_purge(&incoming_data_msgq);
+
+	while (k_msgq_get(&incoming_data_msgq, &buf, K_NO_WAIT) == 0) {
+		net_buf_unref(buf);
+	}
 }
 
 static int ares_if_init(struct usbd_class_data *c_data)
@@ -288,7 +338,8 @@ static void ares_processing_thread_entry(void *p1, void *p2, void *p3)
 
 		LOG_DBG("Processing thread got buffer %p with len %u", buf, buf->len);
 
-		if (ares_interface->protocol->api->handle) {
+		if (ares_interface && ares_interface->protocol && ares_interface->protocol->api &&
+		    ares_interface->protocol->api->handle) {
 			ares_interface->protocol->api->handle(ares_interface->protocol, buf);
 		}
 		// k_busy_wait(3);
@@ -303,31 +354,28 @@ static void ares_processing_thread_entry(void *p1, void *p2, void *p3)
 
 /* === Public API and Setup Function === */
 
-struct ares_udc_buf_info {
-	struct udc_buf_info udc_buf_info;
-	struct k_mutex *mutex;
-} __attribute__((packed));
-
 /* To send data, we can allocate from the general-purpose system pool */
 void buf_cb_unlock(struct net_buf *buf)
 {
-	struct ares_udc_buf_info *buf_info = net_buf_user_data(buf);
-	if (buf_info->mutex) {
-		LOG_DBG("Unlocking mutex %p", buf_info->mutex);
-		k_mutex_unlock(buf_info->mutex);
-	}
 	LOG_DBG("Destroying buffer %p", buf);
 	net_buf_destroy(buf);
 }
 
 UDC_BUF_POOL_DEFINE(tx_pool, 8, 512, sizeof(struct ares_udc_buf_info), buf_cb_unlock);
 
-int ares_usbd_write(struct AresInterface *interface, struct net_buf *buf)
+static int ares_usbd_write_common(struct AresInterface *interface, struct net_buf *buf,
+				  ares_interface_tx_done_cb_t cb, void *user_data)
 {
 	struct usbd_class_data *c_data = ares_if_class_data;
-	struct ares_if_data *data = usbd_class_get_private(c_data);
+	struct ares_if_data *data = NULL;
 	int err;
 
+	if (c_data == NULL) {
+		err = -ENODEV;
+		goto clear_exit;
+	}
+
+	data = usbd_class_get_private(c_data);
 	if (data == NULL) {
 		err = -EINVAL;
 		goto clear_exit;
@@ -343,7 +391,8 @@ int ares_usbd_write(struct AresInterface *interface, struct net_buf *buf)
 
 	struct ares_udc_buf_info *buf_info = net_buf_user_data(buf);
 	if (buf_info) {
-		buf_info->mutex = NULL;
+		buf_info->tx_done = cb;
+		buf_info->tx_user_data = user_data;
 		buf_info->udc_buf_info.ep = ares_if_get_bulk_in(c_data);
 	}
 
@@ -352,6 +401,9 @@ int ares_usbd_write(struct AresInterface *interface, struct net_buf *buf)
 		atomic_clear_bit(&data->state, ARES_IF_FUNCTION_IN_ENGAGED);
 		LOG_ERR("Enqueue error %d", err);
 clear_exit:
+		if (cb) {
+			cb(interface, buf, err, user_data);
+		}
 		net_buf_unref(buf);
 	} else {
 		LOG_DBG("Enqueueing buffer %p", buf);
@@ -359,42 +411,35 @@ clear_exit:
 	return err;
 }
 
-int ares_usbd_write_with_lock(struct AresInterface *interface, struct net_buf *buf,
-			      struct k_mutex *mutex)
+int ares_usbd_write(struct AresInterface *interface, struct net_buf *buf)
+{
+	return ares_usbd_write_common(interface, buf, NULL, NULL);
+}
+
+int ares_usbd_write_with_callback(struct AresInterface *interface, struct net_buf *buf,
+				  ares_interface_tx_done_cb_t cb, void *user_data)
+{
+	return ares_usbd_write_common(interface, buf, cb, user_data);
+}
+
+uint32_t ares_usbd_caps(struct AresInterface *interface)
+{
+	ARG_UNUSED(interface);
+
+	return ARES_INTERFACE_CAP_PACKET | ARES_INTERFACE_CAP_ZERO_COPY |
+	       ARES_INTERFACE_CAP_TX_COMPLETE;
+}
+
+size_t ares_usbd_mtu(struct AresInterface *interface)
 {
 	struct usbd_class_data *c_data = ares_if_class_data;
-	struct ares_if_data *data = usbd_class_get_private(c_data);
-	int err;
 
-	if (data == NULL) {
-		err = -EINVAL;
-		goto clear_exit;
-	}
-	if (!atomic_test_bit(&data->state, ARES_IF_FUNCTION_ENABLED)) {
-		err = -EPERM;
-		goto clear_exit;
-	}
-	if (atomic_test_and_set_bit(&data->state, ARES_IF_FUNCTION_IN_ENGAGED)) {
-		err = -EBUSY;
-		goto clear_exit;
-	}
+	ARG_UNUSED(interface);
 
-	struct ares_udc_buf_info *buf_info = net_buf_user_data(buf);
-	if (buf_info) {
-		buf_info->mutex = mutex;
-		buf_info->udc_buf_info.ep = ares_if_get_bulk_in(c_data);
+	if (c_data == NULL) {
+		return 64U;
 	}
-
-	err = usbd_ep_enqueue(c_data, buf);
-	if (err) {
-		atomic_clear_bit(&data->state, ARES_IF_FUNCTION_IN_ENGAGED);
-		LOG_DBG("locked Enqueue error %d", err);
-clear_exit:
-		net_buf_unref(buf);
-	} else {
-		LOG_DBG("locked Enqueueing buffer %p", buf);
-	}
-	return err;
+	return ares_if_get_mps(c_data);
 }
 
 struct net_buf *ares_interface_alloc_buf(struct AresInterface *interface)
@@ -403,7 +448,8 @@ struct net_buf *ares_interface_alloc_buf(struct AresInterface *interface)
 	if (buf) {
 		struct ares_udc_buf_info *buf_info = net_buf_user_data(buf);
 		if (buf_info) {
-			buf_info->mutex = NULL;
+			buf_info->tx_done = NULL;
+			buf_info->tx_user_data = NULL;
 		}
 	}
 	return buf;
@@ -416,10 +462,19 @@ struct net_buf *ares_interface_alloc_buf_with_data(struct AresInterface *interfa
 	if (buf) {
 		struct ares_udc_buf_info *buf_info = net_buf_user_data(buf);
 		if (buf_info) {
-			buf_info->mutex = NULL;
+			buf_info->tx_done = NULL;
+			buf_info->tx_user_data = NULL;
 		}
 	}
 	return buf;
+}
+
+static void ares_usbd_protocol_event(enum AresProtocolEvent event)
+{
+	if (ares_interface && ares_interface->protocol && ares_interface->protocol->api &&
+	    ares_interface->protocol->api->event) {
+		ares_interface->protocol->api->event(ares_interface->protocol, event);
+	}
 }
 
 // Corrected message callback, same as in sample_usbd.c
@@ -428,25 +483,15 @@ static void ares_usbd_msg_cb(struct usbd_context *const usbd_ctx, const struct u
 	switch (msg->type) {
 	case USBD_STATE_CONFIGURED:
 		// LOG_INF("USB device configured");
-
-		if (ares_interface->protocol->api->event && ares_interface->protocol) {
-			ares_interface->protocol->api->event(ares_interface->protocol,
-							     ARES_PROTOCOL_EVENT_DISCONNECTED);
-		}
+		ares_usbd_set_connected(ares_if_class_data, true);
 		break;
 	case USBD_MSG_RESET:
 		// LOG_INF("USB device reset");
-		if (ares_interface->protocol->api->event && ares_interface->protocol) {
-			ares_interface->protocol->api->event(ares_interface->protocol,
-							     ARES_PROTOCOL_EVENT_CONNECTED);
-		}
+		ares_usbd_set_connected(ares_if_class_data, false);
 		break;
 	case USBD_MSG_SUSPEND:
 		LOG_INF("USB device suspended");
-		if (ares_interface->protocol->api->event && ares_interface->protocol) {
-			ares_interface->protocol->api->event(ares_interface->protocol,
-							     ARES_PROTOCOL_EVENT_DISCONNECTED);
-		}
+		ares_usbd_set_connected(ares_if_class_data, false);
 		break;
 	default:
 		break;
@@ -489,7 +534,7 @@ int ares_usbd_init(struct AresInterface *interface)
 		return err;
 	}
 
-	if (IS_ENABLED(USBD_SUPPORTS_HIGH_SPEED)) {
+	if (USBD_SUPPORTS_HIGH_SPEED && usbd_caps_speed(&ares_usbd) == USBD_SPEED_HS) {
 		err = usbd_add_configuration(&ares_usbd, USBD_SPEED_HS, &ares_hs_config);
 		if (err) {
 			LOG_ERR("Failed to add HS config");

--- a/lib/ares/interface/usb/usb_bulk.h
+++ b/lib/ares/interface/usb/usb_bulk.h
@@ -13,8 +13,10 @@ int ares_usbd_write(struct AresInterface *interface, struct net_buf *buf);
 struct net_buf *ares_interface_alloc_buf(struct AresInterface *interface);
 struct net_buf *ares_interface_alloc_buf_with_data(struct AresInterface *interface, void *data,
 						   size_t len);
-int ares_usbd_write_with_lock(struct AresInterface *interface, struct net_buf *buf,
-			      struct k_mutex *mutex);
+int ares_usbd_write_with_callback(struct AresInterface *interface, struct net_buf *buf,
+				  ares_interface_tx_done_cb_t cb, void *user_data);
+uint32_t ares_usbd_caps(struct AresInterface *interface);
+size_t ares_usbd_mtu(struct AresInterface *interface);
 
 struct AresBulkInterface {
 	struct AresInterface *interface;
@@ -32,7 +34,9 @@ struct AresBulkInterface {
 	struct AresInterfaceAPI ares_bulk_interface_api = {                                        \
 		.init = ares_usbd_init,                                                            \
 		.send = ares_usbd_write,                                                           \
-		.send_with_lock = ares_usbd_write_with_lock,                                       \
+		.send_with_callback = ares_usbd_write_with_callback,                               \
+		.caps = ares_usbd_caps,                                                            \
+		.mtu = ares_usbd_mtu,                                                              \
 		.alloc_buf = ares_interface_alloc_buf,                                             \
 		.alloc_buf_with_data = ares_interface_alloc_buf_with_data,                         \
 	};                                                                                         \

--- a/lib/ares/protocol/dual/dual_protocol.c
+++ b/lib/ares/protocol/dual/dual_protocol.c
@@ -86,14 +86,40 @@ struct net_buf *alloc_and_add_data(struct AresProtocol *protocol, uint8_t *data,
 	}
 }
 
-int send_try_lock(struct AresProtocol *protocol, struct net_buf *buf, struct k_mutex *mutex)
+static int send_with_tx_done(struct AresProtocol *protocol, struct net_buf *buf,
+			     ares_interface_tx_done_cb_t cb, void *user_data)
 {
-	if (protocol->interface->api->send_with_lock && mutex) {
-		return protocol->interface->api->send_with_lock(protocol->interface, buf, mutex);
-	} else {
-		k_mutex_unlock(mutex);
+	if (buf == NULL) {
+		return -ENOMEM;
+	}
+
+	if (cb != NULL) {
+		if (protocol->interface->api->send_with_callback == NULL) {
+			net_buf_unref(buf);
+			return -ENOTSUP;
+		}
+		return protocol->interface->api->send_with_callback(protocol->interface, buf, cb,
+								    user_data);
+	}
+
+	if (protocol->interface->api->send) {
 		return protocol->interface->api->send(protocol->interface, buf);
 	}
+
+	net_buf_unref(buf);
+	return -ENOTSUP;
+}
+
+static void dual_clear_tx_in_flight(struct AresInterface *interface, struct net_buf *buf,
+				    int status, void *user_data)
+{
+	atomic_t *tx_state = user_data;
+
+	ARG_UNUSED(interface);
+	ARG_UNUSED(buf);
+	ARG_UNUSED(status);
+
+	atomic_clear_bit(tx_state, DUAL_TX_IN_FLIGHT);
 }
 
 static void error_handle(struct AresProtocol *protocol, uint16_t req_id, uint16_t error)
@@ -204,9 +230,19 @@ static void usb_offline_clean(struct AresProtocol *protocol)
 {
 	struct tx_msg_bck msg;
 	struct dual_protocol_data *data = protocol->priv_data;
+
+	for (uint8_t i = 0; i < data->func_cnt; i++) {
+		atomic_clear_bit(&data->func_table[i].tx_state, DUAL_TX_IN_FLIGHT);
+	}
+
+	for (uint8_t i = 0; i < data->sync_cnt; i++) {
+		atomic_clear_bit(&data->sync_table[i].tx_state, DUAL_TX_IN_FLIGHT);
+	}
+
 	while (k_msgq_num_used_get(&data->func_tx_bckup_msgq) > 0) {
 		k_msgq_get(&data->func_tx_bckup_msgq, &msg, K_NO_WAIT);
 	}
+	data->func_tx_bckup_cnt = 0;
 }
 
 static void usb_trans_heart_beat(struct k_timer *timer)
@@ -306,11 +342,12 @@ static void parse_func(struct AresProtocol *protocol, func_table_t *map)
 	k_msgq_put(&data->func_tx_bckup_msgq, &msg, K_NO_WAIT);
 	data->func_tx_bckup_cnt++;
 
-	uint8_t *repl_frame = map->buf;
-	if (k_mutex_lock(&map->mutex, K_NO_WAIT) != 0) {
-		LOG_DBG("%s Failed to lock FUNC frame mutex.", data->name);
+	if (atomic_test_and_set_bit(&map->tx_state, DUAL_TX_IN_FLIGHT)) {
+		LOG_DBG("%s FUNC reply frame is still in flight.", data->name);
 		return;
 	}
+
+	uint8_t *repl_frame = map->buf;
 	GET_16BITS(repl_frame, REPL_HEAD_IDX) = REPL_FRAME_HEAD;
 	GET_16BITS(repl_frame, REPL_FUNC_ID_IDX) = map->id;
 	GET_32BITS(repl_frame, REPL_RET_IDX) = (uint32_t)ret;
@@ -324,9 +361,10 @@ static void parse_func(struct AresProtocol *protocol, func_table_t *map)
 
 	int err = 0;
 	struct net_buf *buf = alloc_and_add_data(protocol, repl_frame, frame_len);
-	err = send_try_lock(protocol, buf, &map->mutex);
+	err = send_with_tx_done(protocol, buf, dual_clear_tx_in_flight, &map->tx_state);
 
 	if (err != 0) {
+		atomic_clear_bit(&map->tx_state, DUAL_TX_IN_FLIGHT);
 		LOG_ERR("%s Failed to send REPLY frame.", data->name);
 		return;
 	}
@@ -386,6 +424,9 @@ int dual_sync_flush(struct AresProtocol *protocol, sync_table_t *pack)
 		LOG_ERR("%s Sync pack is NULL.", data->name);
 		return -EINVAL;
 	}
+	if (atomic_test_and_set_bit(&pack->tx_state, DUAL_TX_IN_FLIGHT)) {
+		return -EBUSY;
+	}
 	memcpy(pack->buf + SYNC_DATA_IDX, pack->data, pack->len);
 
 	size_t frame_len = pack->len + SYNC_FRAME_LENGTH_OFFSET;
@@ -397,9 +438,10 @@ int dual_sync_flush(struct AresProtocol *protocol, sync_table_t *pack)
 	// LOG_HEXDUMP_DBG(pack->buf, frame_len, "Sync data to send:");
 
 	struct net_buf *buf = alloc_and_add_data(protocol, pack->buf, frame_len);
-	int ret = send_try_lock(protocol, buf, &pack->mutex);
+	int ret = send_with_tx_done(protocol, buf, dual_clear_tx_in_flight, &pack->tx_state);
 
 	if (ret != 0) {
+		atomic_clear_bit(&pack->tx_state, DUAL_TX_IN_FLIGHT);
 		// LOG_ERR("Failed to send SYNC frame. %d", ret);
 		return -EBUSY;
 	}
@@ -457,6 +499,7 @@ sync_table_t *dual_sync_add(struct AresProtocol *protocol, uint16_t ID, uint8_t 
 	data->sync_table[data->sync_cnt].ID = ID;
 	data->sync_table[data->sync_cnt].len = len;
 	data->sync_table[data->sync_cnt].cb = cb;
+	atomic_set(&data->sync_table[data->sync_cnt].tx_state, 0);
 
 	size_t buf_size = len + SYNC_FRAME_LENGTH_OFFSET;
 	if (data->crc_enabled) {
@@ -465,12 +508,12 @@ sync_table_t *dual_sync_add(struct AresProtocol *protocol, uint16_t ID, uint8_t 
 
 	data->sync_table[data->sync_cnt].buf =
 		k_heap_aligned_alloc(&dual_protocol_heap, 4, buf_size, K_NO_WAIT);
-	memset(data->sync_table[data->sync_cnt].buf, 0, buf_size);
 	if (data->sync_table[data->sync_cnt].buf == NULL) {
 		LOG_ERR("%s Failed to allocate memory for SYNC frame. Count: %d", data->name,
 			data->sync_cnt);
 		return NULL;
 	}
+	memset(data->sync_table[data->sync_cnt].buf, 0, buf_size);
 	GET_16BITS(data->sync_table[data->sync_cnt].buf, SYNC_HEAD_IDX) = SYNC_FRAME_HEAD;
 	GET_16BITS(data->sync_table[data->sync_cnt].buf, SYNC_ID_IDX) = ID;
 	data->sync_cnt++;
@@ -496,6 +539,7 @@ void dual_func_add(struct AresProtocol *protocol, uint16_t id, dual_trans_func_t
 	}
 	data->func_table[data->func_cnt].id = id;
 	data->func_table[data->func_cnt].cb = cb;
+	atomic_set(&data->func_table[data->func_cnt].tx_state, 0);
 	data->func_cnt++;
 }
 
@@ -800,12 +844,14 @@ void ares_dual_protocol_event(struct AresProtocol *protocol, enum AresProtocolEv
 	if (event == ARES_PROTOCOL_EVENT_CONNECTED) {
 		LOG_INF("%s Connection established due to event.", data->name);
 		k_msleep(600);
+		usb_offline_clean(protocol);
 		data->online = true;
 		// 重置状态机状态
 		reset_parser_state(data);
 	} else if (event == ARES_PROTOCOL_EVENT_DISCONNECTED) {
 		LOG_INF("%s Connection lost due to event.", data->name);
 		data->online = false;
+		usb_offline_clean(protocol);
 		// 重置状态机状态
 		reset_parser_state(data);
 	}


### PR DESCRIPTION
## 描述

修复 ARES USB bulk transport 在 MC-02 上的 reconnect/回复路径问题，并补充 USB 更新文档、架构对比和性能数据。

根因是 USB protocol connected 状态和 bulk OUT 真实提交状态没有严格绑定；同时 dual protocol 的 FUNC/SYNC TX in-flight 状态在断连或异常 completion 路径后可能不被清理，导致 host reconnect 后设备仍能收到 FUNC，但 reply path 长期保持 busy，从而不回包。

本 PR 不包含 benchmark-only hook。验证使用正常 `samples/communication/ares_communication` 应用完成。

## 改动类型

- [x] 🐛 Bug 修复
- [ ] ✨ 新功能
- [x] 📝 文档更新
- [ ] 🎨 代码格式/风格调整
- [ ] ♻️ 代码重构
- [x] ⚡ 性能优化
- [x] ✅ 测试相关
- [ ] 🔧 构建/工具相关

## 相关 Issue

N/A

## 测试

- [ ] 代码通过所有 pre-commit 检查
- [x] 在以下开发板上测试通过：
  - [ ] Robomaster Board C
  - [ ] Robomaster Board A
  - [x] DM MC02
  - [ ] 其他：___________

本地验证：

- `west build -d build`
- `west flash -d build --no-rebuild --runner openocd --config boards/damiao/dm_mc02/support/openocd.cfg`
- MC-02 USB enumeration as `ARES Bulk Interface Async`, VID:PID `1209:0001`, full-speed USB
- Three consecutive host reconnect tests completed with replies continuing after reconnect:
  - Run 1: `sent=45949 replies=45449 send_fps=9189.8 reply_fps_over_send=9089.8`
  - Run 2: `sent=46238 replies=45819 send_fps=9247.6 reply_fps_over_send=9163.8`
  - Run 3: `sent=46039 replies=45626 send_fps=9207.8 reply_fps_over_send=9125.2`
- RTT probe:
  - typical: 0.28-0.36 ms
  - average: 0.30-0.39 ms
  - p95: 0.44-0.64 ms
  - p99: 0.56-1.12 ms
  - max observed: 1.4-3.8 ms

## 检查清单

- [x] 我的代码遵循项目的编码规范
- [x] 我已经进行了自我审查
- [x] 我已经添加了必要的注释，特别是在难以理解的地方
- [x] 我已经更新了相关文档
- [ ] 我的改动没有产生新的警告
- [x] 我已经添加了测试来证明我的修复有效或新功能正常工作
- [ ] 新增和现有的单元测试在本地都通过
- [x] 所有文件都包含 SPDX 许可证头

说明：本地 build 仍有项目既有 warning；本 PR 未处理既有 warning。没有新增单元测试，验证以 MC-02 硬件 USB reconnect 和 FUNC/REPL 压测为主。

## 截图/日志

Startup log after reset showed the expected class-driven connection path:

```text
ares_usb_bulk_async: Enable ARES Bulk interface
dual_protocol: dual_protocol Connection established due to event.
```

Performance and architecture details are documented in:

`Documents/updates/ares_usb_transport_update.md`

## 其他说明

This PR targets `refactor/motor-can-scheduler-control` so the diff contains only the USB transport update, not the earlier motor scheduler refactor commits.
